### PR TITLE
Untitled

### DIFF
--- a/src/Text/Hakyll/Tags.hs
+++ b/src/Text/Hakyll/Tags.hs
@@ -149,7 +149,7 @@ renderTagCloud urlFunction minSize maxSize = createHakyllAction renderTagCloud'
     minCount = minimum . map snd . tagCount
     maxCount = maximum . map snd . tagCount
     relative tagMap count = (count - minCount tagMap) /
-                            (maxCount tagMap - minCount tagMap)
+                            (1 + maxCount tagMap - minCount tagMap)
 
     tagCount = map (second $ fromIntegral . length) . M.toList
 


### PR DESCRIPTION
Funny problem, took me some time to realize.
When I start using the tagCloud the output seems to be empty. 
But, after inspecting the oupout, I found that the font-size is set
to zero. I play around with the tags distribution and observe
that if all tags are equally distributed this results a miscalculation
of the font-size. 

This patch should fix the problem, by preventing a division by zero.
