### PR TITLE
Put post publication timestamp into an atom:published field rather than an atom:updated field

### DIFF
--- a/data/templates/atom-item.xml
+++ b/data/templates/atom-item.xml
@@ -2,6 +2,6 @@
     <title>$title$</title>
     <link href="$root$$url$" />
     <id>$root$$url$</id>
-    <updated>$timestamp$</updated>
+    <published>$timestamp$</published>
     <summary type="html"><![CDATA[$description$]]></summary>
 </entry>


### PR DESCRIPTION
This is more in line with the Atom specification, which [states](http://www.atomenabled.org/developers/syndication/atom-format-spec.php#element.published) that

> The "atom:published" element is a Date construct indicating an instant in time associated with an event early in the life cycle of the entry.

while

> The "atom:updated" element is a Date construct indicating the most recent instant in time when an entry or feed was modified in a way the publisher considers significant.

I've been adding `updated` keys to my posts lately, and will probably roll my own Atom feed generator function to incorporate them, but I don't know whether this is functionality you want in Hakyll itself.
