### PR TITLE
Don't relativize urls that lead with "//"

### DIFF
--- a/src/Hakyll/Web/Urls/Relativize.hs
+++ b/src/Hakyll/Web/Urls/Relativize.hs
@@ -44,4 +44,4 @@ relativizeUrls :: String  -- ^ Path to the site root
                -> String  -- ^ Resulting HTML
 relativizeUrls root = withUrls rel
   where
-    rel x = if "/" `isPrefixOf` x then root ++ x else x
+    rel x = if "/" `isPrefixOf` x && not ("//" `isPrefixOf` x) then root ++ x else x


### PR DESCRIPTION
Used to reference absolute path in another domain, without hardcoding protocol (so it works if your site is http or https, and your browser won't complain about unsecure content)
Example: script src="//ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js"
