### PR TITLE
Set author field by config author name

### DIFF
--- a/src/Hakyll/Web/Feed.hs
+++ b/src/Hakyll/Web/Feed.hs
@@ -64,7 +64,7 @@ createFeed feedTemplate itemTemplate url configuration items =
              $ trySetField "updated"     updated
              $ trySetField "title"       (feedTitle configuration)
              $ trySetField "description" (feedDescription configuration)
-             $ trySetField "authorName"  (feedDescription configuration)
+             $ trySetField "authorName"  (feedAuthorName configuration)
              $ trySetField "root"        (feedRoot configuration)
              $ trySetField "url"         url
              $ fromBody body


### PR DESCRIPTION
I can't seem to find the reason of having author field filled with
description.
