### PR TITLE
changes for blaze-html 0.5

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -61,7 +61,8 @@ Library
   Build-Depends:
     base        >= 4      && < 5,
     binary      >= 0.5    && < 0.6,
-    blaze-html  >= 0.4    && < 0.6,
+    blaze-html  >= 0.5    && < 0.6,
+    blaze-markup >= 0.5.1  && < 0.6,
     bytestring  >= 0.9    && < 0.10,
     citeproc-hs >= 0.3.2  && < 0.4,
     containers  >= 0.3    && < 0.5,

--- a/src/Hakyll/Core/Writable.hs
+++ b/src/Hakyll/Core/Writable.hs
@@ -9,8 +9,8 @@ import Data.Word (Word8)
 
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
-import Text.Blaze (Html)
-import Text.Blaze.Renderer.String (renderHtml)
+import Text.Blaze.Html (Html)
+import Text.Blaze.Html.Renderer.String (renderHtml)
 
 import Hakyll.Core.Identifier
 

--- a/src/Hakyll/Web/Blaze.hs
+++ b/src/Hakyll/Web/Blaze.hs
@@ -7,7 +7,8 @@ module Hakyll.Web.Blaze
     , getBodyHtml'
     ) where
 
-import Text.Blaze (Html, toHtml, preEscapedString)
+import Text.Blaze.Html (Html, toHtml)
+import Text.Blaze.Internal (preEscapedString)
 
 import Hakyll.Web.Page
 import Hakyll.Web.Page.Metadata

--- a/src/Hakyll/Web/Tags.hs
+++ b/src/Hakyll/Web/Tags.hs
@@ -52,8 +52,8 @@ import Data.Monoid (mconcat)
 
 import Data.Typeable (Typeable)
 import Data.Binary (Binary, get, put)
-import Text.Blaze.Renderer.String (renderHtml)
-import Text.Blaze ((!), toHtml, toValue)
+import Text.Blaze.Html.Renderer.String (renderHtml)
+import Text.Blaze.Html ((!), toHtml, toValue)
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 

--- a/src/Hakyll/Web/Util/Html.hs
+++ b/src/Hakyll/Web/Util/Html.hs
@@ -5,8 +5,8 @@ module Hakyll.Web.Util.Html
     , escapeHtml
     ) where
 
-import Text.Blaze (toHtml)
-import Text.Blaze.Renderer.String (renderHtml)
+import Text.Blaze.Html (toHtml)
+import Text.Blaze.Html.Renderer.String (renderHtml)
 
 -- | Strip all HTML tags from a string
 --


### PR DESCRIPTION
I find it fails to build with blaze-html 0.5 without these changes. Builds fine on gentoo with them.
