### PR TITLE
Do not escape contents within 'style' tags.

### DIFF
--- a/src/Hakyll/Web/Urls.hs
+++ b/src/Hakyll/Web/Urls.hs
@@ -8,6 +8,7 @@ module Hakyll.Web.Urls
     ) where
 
 import Data.List (isPrefixOf)
+import Data.Char (toLower)
 import System.FilePath (splitPath, takeDirectory, joinPath)
 import qualified Data.Set as S
 
@@ -16,12 +17,19 @@ import qualified Text.HTML.TagSoup as TS
 -- | Apply a function to each URL on a webpage
 --
 withUrls :: (String -> String) -> String -> String
-withUrls f = TS.renderTags . map tag . TS.parseTags
+withUrls f = renderTags' . map tag . TS.parseTags
   where
     tag (TS.TagOpen s a) = TS.TagOpen s $ map attr a
     tag x                = x
     attr (k, v)          = (k, if k `S.member` refs then f v else v)
     refs                 = S.fromList ["src", "href"]
+
+-- | Customized TagSoup renderer.
+-- (The default TagSoup renderer escape CSS within style tags.)
+renderTags' :: [TS.Tag String] -> String
+renderTags' = TS.renderTagsOptions TS.renderOptions
+              { TS.optRawTag = (`elem` ["script", "style"]) . map toLower
+              }
 
 -- | Convert a filepath to an URL starting from the site root
 --


### PR DESCRIPTION
CSS selectors use `>` and `"`, but they get escaped in the default TagSoup renderer. See [here](http://www.w3.org/TR/CSS2/selector.html#pattern-matching) for CSS2 selector syntax.
