### PR TITLE
Make Template support ByteString as well as String

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -65,16 +65,16 @@ Library
 
   Build-Depends:
     base         >= 4      && < 5,
-    binary       >= 0.5    && < 0.6,
+    binary       >= 0.5    && < 0.7,
     blaze-html   >= 0.5    && < 0.6,
     blaze-markup >= 0.5.1  && < 0.6,
-    bytestring   >= 0.9    && < 0.10,
+    bytestring   >= 0.9    && < 0.11,
     citeproc-hs  >= 0.3.2  && < 0.4,
     containers   >= 0.3    && < 0.6,
     cryptohash   >= 0.7    && < 0.8,
-    directory    >= 1.0    && < 1.2,
+    directory    >= 1.0    && < 1.3,
     filepath     >= 1.0    && < 1.4,
-    hamlet       >= 1.0    && < 1.1,
+    hamlet       >= 1.0    && < 1.2,
     mtl          >= 1      && < 2.2,
     old-locale   >= 1.0    && < 1.1,
     old-time     >= 1.0    && < 1.2,
@@ -86,7 +86,7 @@ Library
     tagsoup      >= 0.12.6 && < 0.13,
     text         >= 0.11   && < 1.12,
     time         >= 1.1    && < 1.5,
-    lrucache     >= 1.1.1  && < 1.2
+    lrucache     >= 2.0  && < 2.2
 
   Exposed-Modules:
     Hakyll
@@ -143,8 +143,8 @@ Library
 
   If flag(previewServer)
     Build-depends:
-      snap-core   >= 0.6 && < 0.9,
-      snap-server >= 0.6 && < 0.9
+      snap-core   >= 0.6 && < 0.10,
+      snap-server >= 0.6 && < 0.10
     Cpp-options:
       -DPREVIEW_SERVER
     Other-modules:
@@ -153,7 +153,7 @@ Library
 
   If flag(unixFilter)
     Build-depends:
-      unix >= 2.4 && < 2.6
+      unix >= 2.4 && < 2.7
     Cpp-options:
       -DUNIX_FILTER
     Other-modules:
@@ -173,16 +173,16 @@ Test-suite hakyll-tests
     test-framework-quickcheck2 >= 0.2 && < 0.3,
     -- Copy pasted from hakyll dependencies:
     base         >= 4      && < 5,
-    binary       >= 0.5    && < 0.6,
+    binary       >= 0.5    && < 0.7,
     blaze-html   >= 0.5    && < 0.6,
     blaze-markup >= 0.5.1  && < 0.6,
-    bytestring   >= 0.9    && < 0.10,
+    bytestring   >= 0.9    && < 0.11,
     citeproc-hs  >= 0.3.2  && < 0.4,
     containers   >= 0.3    && < 0.6,
     cryptohash   >= 0.7    && < 0.8,
-    directory    >= 1.0    && < 1.2,
+    directory    >= 1.0    && < 1.3,
     filepath     >= 1.0    && < 1.4,
-    hamlet       >= 1.0    && < 1.1,
+    hamlet       >= 1.0    && < 1.2,
     mtl          >= 1      && < 2.2,
     old-locale   >= 1.0    && < 1.1,
     old-time     >= 1.0    && < 1.2,
@@ -194,8 +194,8 @@ Test-suite hakyll-tests
     tagsoup      >= 0.12.6 && < 0.13,
     text         >= 0.11   && < 1.12,
     time         >= 1.1    && < 1.5,
-    lrucache     >= 1.1.1  && < 1.2,
-    unix         >= 2.4    && < 2.6
+    lrucache     >= 1.1.1  && < 2.2,
+    unix         >= 2.4    && < 2.7
 
   Other-modules:
     Hakyll.Web.Util.Html.Tests

--- a/src/Hakyll/Core/Resource/Provider/File.hs
+++ b/src/Hakyll/Core/Resource/Provider/File.hs
@@ -28,7 +28,4 @@ fileResourceProvider configuration = do
                               (LB.readFile . unResource)
                               (mtime . unResource)
   where
-    mtime r = do
-        ct <- toCalendarTime =<< getModificationTime r
-        let str = formatCalendarTime defaultTimeLocale "%s" ct
-        return $ readTime defaultTimeLocale "%s" str
+    mtime r = getModificationTime r

--- a/src/Hakyll/Core/Store.hs
+++ b/src/Hakyll/Core/Store.hs
@@ -45,8 +45,8 @@ data Store = Store
     }
 
 -- | The size of the in-memory cache to use in items.
-storeLRUSize :: Maybe Integer
-storeLRUSize = Just 500
+storeLRUSize :: Integer
+storeLRUSize = 500
 
 -- | Initialize the store
 --
@@ -64,8 +64,9 @@ makeStore inMemory directory = do
 --
 cacheInsert :: (Binary a, Typeable a) => Store -> FilePath -> a -> IO ()
 cacheInsert (Store _ Nothing)   _    _     = return ()
-cacheInsert (Store _ (Just lru)) path value =
+cacheInsert (Store _ (Just lru)) path value = do
     LRU.insert path (Storable value) lru
+    return ()
 
 -- | Auxiliary: get an item from the cache
 --

--- a/src/Hakyll/Core/Util/File.hs
+++ b/src/Hakyll/Core/Util/File.hs
@@ -8,7 +8,7 @@ module Hakyll.Core.Util.File
     ) where
 
 import Control.Applicative ((<$>))
-import System.Time (ClockTime)
+import Data.Time.Clock (UTCTime)
 import Control.Monad (forM, filterM)
 import Data.List (isPrefixOf)
 import System.Directory ( createDirectoryIfMissing, doesDirectoryExist
@@ -52,7 +52,7 @@ getRecursiveContents includeDirs topdir = do
 -- | Check if a timestamp is obsolete compared to the timestamps of a number of
 -- files. When they are no files, it is never obsolete.
 --
-isObsolete :: ClockTime    -- ^ The time to check.
+isObsolete :: UTCTime    -- ^ The time to check.
            -> [FilePath]   -- ^ Dependencies of the cached file.
            -> IO Bool
 isObsolete _ [] = return False

--- a/src/Hakyll/Web/Feed.hs
+++ b/src/Hakyll/Web/Feed.hs
@@ -27,6 +27,7 @@ import Control.Category (id)
 import Control.Arrow ((>>>), arr, (&&&))
 import Control.Monad ((<=<))
 import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Monoid
 
 import Hakyll.Core.Compiler
 import Hakyll.Web.Page
@@ -55,12 +56,13 @@ data FeedConfiguration = FeedConfiguration
 -- The items should be sorted on date. The @$updated@ field should be set for
 -- each item.
 --
-createFeed :: Template           -- ^ Feed template
-           -> Template           -- ^ Item template
+createFeed :: TemplateString a =>
+              Template a         -- ^ Feed template
+           -> Template a         -- ^ Item template
            -> String             -- ^ URL of the feed
            -> FeedConfiguration  -- ^ Feed configuration
-           -> [Page String]      -- ^ Items to include
-           -> String             -- ^ Resulting feed
+           -> [Page a]           -- ^ Items to include
+           -> a                  -- ^ Resulting feed
 createFeed feedTemplate itemTemplate url configuration items =
     pageBody $ applyTemplate feedTemplate
              $ trySetField "updated"     updated
@@ -77,7 +79,7 @@ createFeed feedTemplate itemTemplate url configuration items =
                             . trySetField "root" (feedRoot configuration)
 
     -- Body: concatenated items
-    body = concat $ map pageBody items'
+    body = mconcat $ map pageBody items'
 
     -- Take the first updated, which should be the most recent
     updated = fromMaybe "Unknown" $ do

--- a/src/Hakyll/Web/Page/List.hs
+++ b/src/Hakyll/Web/Page/List.hs
@@ -15,7 +15,7 @@ module Hakyll.Web.Page.List
     , sortByBaseName
     ) where
 
-import Control.Arrow ((>>>), arr)
+import Control.Arrow ((>>>), arr, (>>^))
 import Data.List (sortBy)
 import Data.Monoid (Monoid, mconcat)
 import Data.Ord (comparing)
@@ -30,31 +30,33 @@ import Hakyll.Web.Template
 
 -- | Set a field of a page to a listing of pages
 --
-setFieldPageList :: ([Page String] -> [Page String])  
+setFieldPageList :: TemplateString a =>
+                    ([Page a] -> [Page a])
                  -- ^ Determines list order
-                 -> Identifier Template               
+                 -> Identifier (Template a)
                  -- ^ Applied to every page
                  -> String
                  -- ^ Key indicating which field should be set
-                 -> Pattern (Page String)             
+                 -> Pattern (Page a)
                  -- ^ Selects pages to include in the list
-                 -> Compiler (Page String) (Page String)
+                 -> Compiler (Page a) (Page a)
                  -- ^ Compiler that sets the page list in a field
 setFieldPageList sort template key pattern =
-    requireAllA pattern $ setFieldA key $ pageListCompiler sort template
+    requireAllA pattern $ setFieldA key $ pageListCompiler sort template >>^ tsToString
 
 -- | Create a list of pages
 --
-pageListCompiler :: ([Page String] -> [Page String])  -- ^ Determine list order
-                 -> Identifier Template               -- ^ Applied to pages
-                 -> Compiler [Page String] String     -- ^ Compiles page list
+pageListCompiler :: TemplateString a =>
+                    ([Page a] -> [Page a])  -- ^ Determine list order
+                 -> Identifier (Template a) -- ^ Applied to pages
+                 -> Compiler [Page a] a     -- ^ Compiles page list
 pageListCompiler sort template =
     arr sort >>> applyTemplateToList template >>> arr concatPages
 
 -- | Apply a template to every page in a list
 --
-applyTemplateToList :: Identifier Template
-                    -> Compiler [Page String] [Page String]
+applyTemplateToList :: TemplateString a => Identifier (Template a)
+                    -> Compiler [Page a] [Page a]
 applyTemplateToList identifier =
     require identifier $ \posts template -> map (applyTemplate template) posts
 

--- a/src/Hakyll/Web/Preview/Poll.hs
+++ b/src/Hakyll/Web/Preview/Poll.hs
@@ -8,6 +8,7 @@ import Control.Applicative ((<$>))
 import Control.Concurrent (threadDelay)
 import Control.Monad (filterM)
 import System.Time (getClockTime)
+import Data.Time
 import System.Directory (getModificationTime, doesFileExist)
 
 import Hakyll.Core.Configuration
@@ -18,7 +19,7 @@ previewPoll :: HakyllConfiguration  -- ^ Configuration
             -> IO [FilePath]        -- ^ Updating action
             -> IO ()                -- ^ Can block forever
 previewPoll _ update = do
-    time <- getClockTime
+    time <- getCurrentTime
     loop time =<< update
   where
     delay = 1000000

--- a/src/Hakyll/Web/Template/Internal.hs
+++ b/src/Hakyll/Web/Template/Internal.hs
@@ -1,38 +1,85 @@
 -- | Module containing the template data structure
 --
-{-# LANGUAGE GeneralizedNewtypeDeriving, DeriveDataTypeable #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, DeriveDataTypeable, FlexibleInstances  #-}
 module Hakyll.Web.Template.Internal
     ( Template (..)
     , TemplateElement (..)
+    , TemplateString (..)
     ) where
 
 import Control.Applicative ((<$>))
 
 import Data.Binary (Binary, get, getWord8, put, putWord8)
 import Data.Typeable (Typeable)
-
+import Data.Monoid
+import qualified Data.ByteString.Char8 as SBS
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import Hakyll.Core.Writable
+import Hakyll.Core.Compiler
+import Hakyll.Core.Resource
+import Control.Arrow
+import Data.String
+import Data.List
+
+-- | The typeclass of string-like types that can be used to build a template.
+class (Monoid a, IsString a, Binary a, Show a, Eq a, Typeable a, Writable a, Ord a) => TemplateString a where
+  tsNull :: a -> Bool
+  tsIsPrefixOf :: a -> a -> Bool
+  tsToString :: a -> String
+  tsDrop :: Int -> a -> a
+  tsBreak :: (Char -> Bool) -> a -> (a, a)
+  tsBreak f = tsSpan (not . f)
+  tsSpan :: (Char -> Bool) -> a -> (a, a)
+  tsSpan f = tsBreak (not . f)
+  tsGetResource :: Compiler Resource a
+
+instance TemplateString [Char] where
+  tsNull = null
+  tsIsPrefixOf = isPrefixOf
+  tsToString = id
+  tsDrop = drop
+  tsBreak = break
+  tsSpan = span
+  tsGetResource = getResourceString
+
+instance TemplateString SBS.ByteString where
+  tsNull = SBS.null
+  tsIsPrefixOf = SBS.isPrefixOf
+  tsToString = SBS.unpack
+  tsDrop n = SBS.drop (fromIntegral n)
+  tsBreak = SBS.break
+  tsSpan = SBS.span
+  tsGetResource = getResourceLBS >>^ (SBS.concat . LBS.toChunks)
+  
+instance TemplateString LBS.ByteString where
+  tsNull = LBS.null
+  tsIsPrefixOf = LBS.isPrefixOf
+  tsToString = LBS.unpack
+  tsDrop n = LBS.drop (fromIntegral n)
+  tsBreak = LBS.break
+  tsSpan = LBS.span
+  tsGetResource = getResourceLBS
 
 -- | Datatype used for template substitutions.
 --
-newtype Template = Template
-    { unTemplate :: [TemplateElement]
+newtype Template a = Template
+    { unTemplate :: [TemplateElement a]
     }
     deriving (Show, Eq, Binary, Typeable)
 
-instance Writable Template where
+instance TemplateString a => Writable (Template a) where
     -- Writing a template is impossible
     write _ _ = return ()
 
 -- | Elements of a template.
 --
-data TemplateElement
-    = Chunk String
+data TemplateElement a
+    = Chunk a
     | Key String
     | Escaped
     deriving (Show, Eq, Typeable)
 
-instance Binary TemplateElement where
+instance TemplateString a => Binary (TemplateElement a) where
     put (Chunk string)    = putWord8 0 >> put string
     put (Key key)  = putWord8 1 >> put key
     put (Escaped) = putWord8 2

--- a/src/Hakyll/Web/Template/Read/Hakyll.hs
+++ b/src/Hakyll/Web/Template/Read/Hakyll.hs
@@ -1,5 +1,6 @@
 -- | Read templates in Hakyll's native format
 --
+{-# LANGUAGE OverloadedStrings #-}
 module Hakyll.Web.Template.Read.Hakyll
     ( readTemplate
     ) where
@@ -11,25 +12,25 @@ import Hakyll.Web.Template.Internal
 
 -- | Construct a @Template@ from a string.
 --
-readTemplate :: String -> Template
+readTemplate :: TemplateString a => a -> Template a
 readTemplate = Template . readTemplate'
   where
-    readTemplate' [] = []
     readTemplate' string
-        | "$$" `isPrefixOf` string =
-            Escaped : readTemplate' (drop 2 string)
-        | "$" `isPrefixOf` string =
-            case readKey (drop 1 string) of
-                Just (key, rest) -> Key key : readTemplate' rest
-                Nothing          -> Chunk "$" : readTemplate' (drop 1 string)
+        | tsNull string = []
+        | "$$" `tsIsPrefixOf` string =
+            Escaped : readTemplate' (tsDrop 2 string)
+        | "$" `tsIsPrefixOf` string =
+            case readKey (tsDrop 1 string) of
+                Just (key, rest) -> Key (tsToString key) : readTemplate' rest
+                Nothing          -> Chunk "$" : readTemplate' (tsDrop 1 string)
         | otherwise =
-            let (chunk, rest) = break (== '$') string
+            let (chunk, rest) = tsBreak (== '$') string
             in Chunk chunk : readTemplate' rest
 
     -- Parse an key into (key, rest) if it's valid, and return
     -- Nothing otherwise
     readKey string =
-        let (key, rest) = span isAlphaNum string
-        in if not (null key) && "$" `isPrefixOf` rest
-            then Just (key, drop 1 rest)
+        let (key, rest) = tsSpan isAlphaNum string
+        in if not (tsNull key) && "$" `tsIsPrefixOf` rest
+            then Just (key, tsDrop 1 rest)
             else Nothing

--- a/src/Hakyll/Web/Template/Read/Hamlet.hs
+++ b/src/Hakyll/Web/Template/Read/Hamlet.hs
@@ -8,17 +8,18 @@ module Hakyll.Web.Template.Read.Hamlet
 
 import Text.Hamlet (HamletSettings, defaultHamletSettings)
 import Text.Hamlet.RT
+import Data.String
 
 import Hakyll.Web.Template.Internal
 
 -- | Read a hamlet template using the default settings
 --
-readHamletTemplate :: String -> Template
+readHamletTemplate :: TemplateString a => String -> Template a
 readHamletTemplate = readHamletTemplateWith defaultHamletSettings
 
 -- | Read a hamlet template using the specified settings
 --
-readHamletTemplateWith :: HamletSettings -> String -> Template
+readHamletTemplateWith :: TemplateString a => HamletSettings -> String -> Template a
 readHamletTemplateWith settings string =
     let result = parseHamletRT settings string
     in case result of
@@ -29,13 +30,13 @@ readHamletTemplateWith settings string =
 
 -- | Convert a 'HamletRT' to a 'Template'
 --
-fromHamletRT :: HamletRT  -- ^ Hamlet runtime template
-             -> Template  -- ^ Hakyll template
+fromHamletRT :: TemplateString a => HamletRT   -- ^ Hamlet runtime template
+                                 -> Template a -- ^ Hakyll template
 fromHamletRT (HamletRT sd) = Template $ map fromSimpleDoc sd
   where
-    fromSimpleDoc :: SimpleDoc -> TemplateElement
-    fromSimpleDoc (SDRaw chunk) = Chunk chunk
-    fromSimpleDoc (SDVar [var]) = Key var
+    fromSimpleDoc :: TemplateString a => SimpleDoc -> TemplateElement a
+    fromSimpleDoc (SDRaw chunk) = Chunk (fromString chunk)
+    fromSimpleDoc (SDVar [var]) = Key (fromString var)
     fromSimpleDoc (SDVar _) = error
         "Hakyll.Web.Template.Read.Hamlet.fromHamletRT: \
         \Hakyll does not support '.' in identifier names when using \


### PR DESCRIPTION
This might require some changes to hakyll.hs files that do this:
     compile templateCompiler
to instead specify what the target is:
     compile (templateCompiler :: Compiler Resource (Template String))

Also any bare references to Template need to be changed to Template String.