### PR TITLE
Allow parsing of relaxed ISO8601 date format in published metadata field

### DIFF
--- a/src/Hakyll/Web/Page/Metadata.hs
+++ b/src/Hakyll/Web/Page/Metadata.hs
@@ -175,6 +175,7 @@ getUTCMaybe :: TimeLocale     -- ^ Output time locale
 getUTCMaybe locale page = msum
     [ fromPublished "%a, %d %b %Y %H:%M:%S UT"
     , fromPublished "%Y-%m-%dT%H:%M:%SZ"
+    , fromPublished "%Y-%m-%d %H:%M:%S"
     , fromPublished "%B %e, %Y %l:%M %p"
     , fromPublished "%B %e, %Y"
     , getFieldMaybe "path" page >>= parseTime' "%Y-%m-%d" .


### PR DESCRIPTION
Many of HTML to Markdown converters output non-ISO8601 through YAML emitters (e.g. https://github.com/thomasf/exitwp) YAML (and other systems) allow the T separator to be replaced by a space for increased readability (see http://sourceforge.net/mailarchive/message.php?msg_id=29987568).
