### PR TITLE
Added %Y-%m-%d format to enable short date parsing in metadata

### DIFF
--- a/src/Hakyll/Web/Page/Metadata.hs
+++ b/src/Hakyll/Web/Page/Metadata.hs
@@ -186,6 +186,7 @@ getUTCMaybe locale page = msum $
         [ "%a, %d %b %Y %H:%M:%S UT"
         , "%Y-%m-%dT%H:%M:%SZ"
         , "%Y-%m-%d %H:%M:%S"
+        , "%Y-%m-%d"
         , "%B %e, %Y %l:%M %p"
         , "%B %e, %Y"
         ]


### PR DESCRIPTION
This is a tiny fix that allows to use short dates in post metadata.
For example:

```
title: Hello World!
date: 2012-11-10

Hello!
```
