### PR TITLE
Support timezones

### DIFF
--- a/src/Hakyll/Web/Template/Context.hs
+++ b/src/Hakyll/Web/Template/Context.hs
@@ -127,13 +127,30 @@ titleField key = mapContext takeBaseName $ pathField key
 -- | When the metadata has a field called @published@ in one of the
 -- following formats then this function can render the date.
 --
---   * @Sun, 01 Feb 2000 13:00:00 UT@ (RSS date format)
+--   * @Mon, 06 Sep 2010 00:01:00 +0000@
 --
---   * @2000-02-01T13:00:00Z@ (Atom date format)
+--   * @Mon, 06 Sep 2010 00:01:00 UTC@
 --
---   * @February 1, 2000 1:00 PM@ (PM is usually uppercase)
+--   * @Mon, 06 Sep 2010 00:01:00@
 --
---   * @February 1, 2000@ (assumes 12:00 AM for the time)
+--   * @2010-09-06T00:01:00+0000@
+--
+--   * @2010-09-06T00:01:00Z@
+--
+--   * @2010-09-06T00:01:00@
+--
+--   * @2010-09-06 00:01:00+0000@
+--
+--   * @2010-09-06 00:01:00@
+--
+--   * @September 06, 2010 00:01 AM@
+--
+-- Following date-only formats are supported too (@00:00:00@ for time is
+-- assumed)
+--
+--   * @2010-09-06@
+--
+--   * @September 06, 2010@
 --
 -- Alternatively, when the metadata has a field called @path@ in a
 -- @folder/yyyy-mm-dd-title.extension@ format (the convention for pages)
@@ -180,9 +197,9 @@ getItemUTC locale id' = do
         "could not parse time for " ++ show id'
     parseTime' = parseTime locale
     formats    =
-        [ "%a, %d %b %Y %H:%M:%S UT"
-        , "%Y-%m-%dT%H:%M:%SZ"
-        , "%Y-%m-%d %H:%M:%S"
+        [ "%a, %d %b %Y %H:%M:%S %Z"
+        , "%Y-%m-%dT%H:%M:%S%Z"
+        , "%Y-%m-%d %H:%M:%S%Z"
         , "%Y-%m-%d"
         , "%B %e, %Y %l:%M %p"
         , "%B %e, %Y"


### PR DESCRIPTION
This patch adds support for timezones in date formats.

``` haskell
parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Z" "2000-02-02T00:00:00+0100" :: Maybe UTCTime
-- Just 2000-02-01 23:00:00 UTC
parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Z" "2000-02-02T00:00:00Z" :: Maybe UTCTime
-- Just 2000-02-02 00:00:00 UTC
parseTime defaultTimeLocale "%Y-%m-%d %H:%M:%S%Z" "2000-02-02 00:00:00" :: Maybe UTCTime
-- Just 2000-02-02 00:00:00 UTC
```
