### PR TITLE
Allow overriding the `deploy` command with Haskell code

### DIFF
--- a/src/Hakyll/Commands.hs
+++ b/src/Hakyll/Commands.hs
@@ -14,7 +14,6 @@ module Hakyll.Commands
 
 --------------------------------------------------------------------------------
 import           System.Exit                (ExitCode (ExitSuccess), exitWith)
-import           System.Process             (system)
 
 
 --------------------------------------------------------------------------------
@@ -109,9 +108,7 @@ server _ _ = previewServerDisabled
 --------------------------------------------------------------------------------
 -- | Upload the site
 deploy :: Configuration -> IO ()
-deploy conf = do
-    _ <- system $ deployCommand conf
-    return ()
+deploy conf = deploySite conf conf
 
 
 --------------------------------------------------------------------------------

--- a/src/Hakyll/Core/Configuration.hs
+++ b/src/Hakyll/Core/Configuration.hs
@@ -8,9 +8,11 @@ module Hakyll.Core.Configuration
 
 
 --------------------------------------------------------------------------------
+import           Control.Monad      (void)
 import           Data.Default       (Default(..))
 import           Data.List          (isPrefixOf, isSuffixOf)
 import           System.FilePath    (normalise, takeFileName)
+import           System.Process     (system)
 
 
 --------------------------------------------------------------------------------
@@ -52,6 +54,16 @@ data Configuration = Configuration
       -- > ./site deploy
       --
       deployCommand        :: String
+    , -- | Function to deploy the site from Haskell.
+      --
+      -- By default, this command executes the shell command stored in
+      -- 'deployCommand'. If you override it, 'deployCommand' will not
+      -- be used implicitely.
+      --
+      -- The 'Configuration' object is passed as a parameter to this
+      -- function.
+      --
+      deploySite           :: Configuration -> IO ()
     , -- | Use an in-memory cache for items. This is faster but uses more
       -- memory.
       inMemoryCache        :: Bool
@@ -71,6 +83,7 @@ defaultConfiguration = Configuration
     , providerDirectory    = "."
     , ignoreFile           = ignoreFile'
     , deployCommand        = "echo 'No deploy command specified'"
+    , deploySite           = void . system . deployCommand
     , inMemoryCache        = True
     }
   where


### PR DESCRIPTION
By overriding `deploySite` with a `Configuration -> IO ()` code, the user can execute Haskell code to deploy the site rather than shell code.

The default behaviour honors the `deployCommand` configuration field and is backward compatible.
