### PR TITLE
Adding short form date parsing

### DIFF
--- a/src/Hakyll/Web/Template/Context.hs
+++ b/src/Hakyll/Web/Template/Context.hs
@@ -203,6 +203,7 @@ getItemUTC locale id' = do
         , "%Y-%m-%d"
         , "%B %e, %Y %l:%M %p"
         , "%B %e, %Y"
+        , "%b %d, %Y"
         ]
 
 


### PR DESCRIPTION
I use `date: Apr 02, 2012` in my articles, so I added the short form parsing rule.
