### PR TITLE
Deploy should propagate error code

### DIFF
--- a/src/Hakyll/Commands.hs
+++ b/src/Hakyll/Commands.hs
@@ -94,7 +94,7 @@ server _ _ = previewServerDisabled
 
 --------------------------------------------------------------------------------
 -- | Upload the site
-deploy :: Configuration -> IO ()
+deploy :: Configuration -> IO ExitCode
 deploy conf = deploySite conf conf
 
 

--- a/src/Hakyll/Core/Configuration.hs
+++ b/src/Hakyll/Core/Configuration.hs
@@ -12,6 +12,7 @@ import           Control.Monad    (void)
 import           Data.Default     (Default (..))
 import           Data.List        (isPrefixOf, isSuffixOf)
 import           System.Directory (canonicalizePath)
+import           System.Exit      (ExitCode)
 import           System.FilePath  (isAbsolute, normalise, takeFileName)
 import           System.IO.Error  (catchIOError)
 import           System.Process   (system)
@@ -65,7 +66,7 @@ data Configuration = Configuration
       -- The 'Configuration' object is passed as a parameter to this
       -- function.
       --
-      deploySite           :: Configuration -> IO ()
+      deploySite           :: Configuration -> IO ExitCode
     , -- | Use an in-memory cache for items. This is faster but uses more
       -- memory.
       inMemoryCache        :: Bool
@@ -84,8 +85,8 @@ defaultConfiguration = Configuration
     , tmpDirectory         = "_cache/tmp"
     , providerDirectory    = "."
     , ignoreFile           = ignoreFile'
-    , deployCommand        = "echo 'No deploy command specified'"
-    , deploySite           = void . system . deployCommand
+    , deployCommand        = "echo 'No deploy command specified' && exit 1"
+    , deploySite           = system . deployCommand
     , inMemoryCache        = True
     }
   where

--- a/src/Hakyll/Main.hs
+++ b/src/Hakyll/Main.hs
@@ -44,7 +44,7 @@ hakyllWith conf rules = do
         Build   _   -> Commands.build conf verbosity' rules >>= exitWith
         Check   _ _ -> Commands.check conf verbosity' check'
         Clean   _   -> Commands.clean conf
-        Deploy  _   -> Commands.deploy conf
+        Deploy  _   -> Commands.deploy conf >>= exitWith
         Help    _   -> showHelp
         Preview _ p -> Commands.preview conf verbosity' rules p
         Rebuild _   -> Commands.rebuild conf verbosity' rules >>= exitWith


### PR DESCRIPTION
And return 1 if neither deployCommand and deploySite is set.

Making #154 more complete.

`&& exit 1` trick seems to work with Linux, Mac OS and apparently even Windows.
