### PR TITLE
Deepseq stderr before closing the handle 

### DIFF
--- a/src/Hakyll/Core/UnixFilter.hs
+++ b/src/Hakyll/Core/UnixFilter.hs
@@ -129,6 +129,7 @@ unixFilterIO writer reader programName args input = do
 
     -- Read from stderr
     _ <- forkIO $ do
+        hSetEncoding errh localeEncoding
         err <- hGetContents errh
         _   <- deepseq err (return err)
         hClose errh


### PR DESCRIPTION
Otherwise laziness allows for the handle to be closed withouth receiving the
input. This caused that no error messages were printed when `unixFilter`s
failed.

The second commit sets the handle's locale as it's done for stdin and stdout. Is it actually needed?
