### PR TITLE
Make work with new version of fsnotify

### DIFF
--- a/src/Hakyll/Preview/Poll.hs
+++ b/src/Hakyll/Preview/Poll.hs
@@ -53,7 +53,7 @@ watchUpdates conf update = do
             shouldIgnore <- shouldIgnoreFile conf path
             return $ not shouldIgnore && matches pattern identifier
 
-    watchTree manager providerDir (not . isRemove) $ \event -> do
+    void $ watchTree manager providerDir (not . isRemove) $ \event -> do
         ()       <- takeMVar lock
         allowed' <- allowed event
         when allowed' $ update' event (encodeString providerDir)


### PR DESCRIPTION
Hi Jasper.

I stuck in a 'void' to make a return type of version 0.0.11 of fsnotify be ignored and allow compilation.

Let me know if this is okay :)
