### PR TITLE
add preview port Configuration field

### DIFF
--- a/src/Hakyll/Core/Configuration.hs
+++ b/src/Hakyll/Core/Configuration.hs
@@ -69,6 +69,10 @@ data Configuration = Configuration
     , -- | Use an in-memory cache for items. This is faster but uses more
       -- memory.
       inMemoryCache        :: Bool
+    , -- | Override default port for preview server. Default is 8000.
+      -- One can also override the port as a command line argument:
+      -- ./site preview -p 1234
+      previewPort          :: Int
     }
 
 --------------------------------------------------------------------------------
@@ -87,6 +91,7 @@ defaultConfiguration = Configuration
     , deployCommand        = "echo 'No deploy command specified' && exit 1"
     , deploySite           = system . deployCommand
     , inMemoryCache        = True
+    , previewPort          = 8000
     }
   where
     ignoreFile' path

--- a/src/Hakyll/Main.hs
+++ b/src/Hakyll/Main.hs
@@ -34,7 +34,7 @@ hakyll = hakyllWith Config.defaultConfiguration
 -- configuration
 hakyllWith :: Config.Configuration -> Rules a -> IO ()
 hakyllWith conf rules = do
-    args' <- cmdArgs hakyllArgs
+    args' <- cmdArgs (hakyllArgs conf)
 
     let verbosity' = if verbose args' then Logger.Debug else Logger.Message
         check'     =
@@ -55,7 +55,7 @@ hakyllWith conf rules = do
 --------------------------------------------------------------------------------
 -- | Show usage information.
 showHelp :: IO ()
-showHelp = print $ CA.helpText [] CA.HelpFormatOne $ cmdArgsMode hakyllArgs
+showHelp = print $ CA.helpText [] CA.HelpFormatOne $ cmdArgsMode (hakyllArgs Config.defaultConfiguration)
 
 
 --------------------------------------------------------------------------------
@@ -73,22 +73,23 @@ data HakyllArgs
 
 
 --------------------------------------------------------------------------------
-hakyllArgs :: HakyllArgs
-hakyllArgs = modes
+hakyllArgs :: Config.Configuration -> HakyllArgs
+hakyllArgs conf = modes
     [ (Build $ verboseFlag def) &= help "Generate the site"
     , (Check (verboseFlag def) (False &= help "Check internal links only")) &=
         help "Validate the site output"
     , (Clean $ verboseFlag def) &= help "Clean up and remove cache"
     , (Deploy $ verboseFlag def) &= help "Upload/deploy your site"
     , (Help $ verboseFlag def) &= help "Show this message" &= auto
-    , (Preview (verboseFlag def) (portFlag 8000)) &=
+    , (Preview (verboseFlag def) (portFlag defaultPort)) &=
         help "[Deprecated] Please use the watch command"
     , (Rebuild $ verboseFlag def) &= help "Clean and build again"
-    , (Server (verboseFlag def) (portFlag 8000)) &=
+    , (Server (verboseFlag def) (portFlag defaultPort)) &=
         help "Start a preview server"
-    , (Watch (verboseFlag def) (portFlag 8000) (noServerFlag False) &=
+    , (Watch (verboseFlag def) (portFlag defaultPort) (noServerFlag False) &=
        help "Autocompile on changes and start a preview server.  You can watch and recompile without running a server with --no-server.")
     ] &= help "Hakyll static site compiler" &= program progName
+    where defaultPort = Config.previewPort conf
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a field to the `Configuration` structure called `previewPort` that allows one to specify the default port to listen on when running the preview server. This is useful when a service already runs on the default port of `8000`, since it's a hassle to keep typing `./site preview -p 4000` for example instead of just `./site preview`.

This would be very helpful for me and I imagine/hope others as well. Let me know if you'd like me to change anything!
