### PR TITLE
Fix incorrect output of toSiteRoot on Windows.

### DIFF
--- a/src/Hakyll/Web/Html.hs
+++ b/src/Hakyll/Web/Html.hs
@@ -25,7 +25,7 @@ import           Data.Char                       (digitToInt, intToDigit,
                                                   isDigit, toLower)
 import           Data.List                       (isPrefixOf)
 import qualified Data.Set                        as S
-import           System.FilePath                 (joinPath, splitPath,
+import           System.FilePath.Posix           (joinPath, splitPath,
                                                   takeDirectory)
 import           Text.Blaze.Html                 (toHtml)
 import           Text.Blaze.Html.Renderer.String (renderHtml)


### PR DESCRIPTION
toSiteRoot uses splitPath, joinPath, and takeDirectory from the
System.FilePath module. On Windows systems, the implementation of
joinPath will build up a path using the Windows path separator "\".

We don't want this behavior since the paths we are working with
are always URLs, so we force POSIX behavior for System.FilePath.

Running `cabal test` on Windows, the following test was failing:

```
-- tests/Hakyll/Web/Html/Tests.hs:
"../.." @=? toSiteRoot "foo/bar/qux"
...
[ 4] toSiteRoot: [Failed]
expected: "../.."
but got: "..\\.."
```

This fix will cause that test to pass on Windows by using POSIX behavior within Hakyll.Web.Html.
