### PR TITLE
Add http://techblog.rosedu.org to Hakyll Examples

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -67,6 +67,8 @@ this list. This list has no particular ordering.
   [source](https://github.com/piyush-kurur-pages/website)
 - <http://web.engr.oregonstate.edu/~walkiner/>,
   [source](https://github.com/walkie/WebPage)
+- <http://techblog.rosedu.org/>,
+  [source](https://github.com/rosedu/techblog)
 
 ## Hakyll 3.X
 


### PR DESCRIPTION
A technical blog by ROSEdu (Romanian Open Source Education) which was recently moved to Hakyll. Still WIP on some parts.
