### PR TITLE
Fix issue with syntax highlighting + line nums.

### DIFF
--- a/web/css/syntax.css
+++ b/web/css/syntax.css
@@ -3,16 +3,16 @@ table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode, table.sourceCode
    { margin: 0; padding: 0; border: 0; vertical-align: baseline; border: none; }
 td.lineNumbers { border-right: 1px solid #AAAAAA; text-align: right; color: #AAAAAA; padding-right: 5px; padding-left: 5px; }
 td.sourceCode { padding-left: 5px; }
-pre.sourceCode span.kw { color: #007020; font-weight: bold; }
-pre.sourceCode span.dt { color: #902000; }
-pre.sourceCode span.dv { color: #40a070; }
-pre.sourceCode span.bn { color: #40a070; }
-pre.sourceCode span.fl { color: #40a070; }
-pre.sourceCode span.ch { color: #4070a0; }
-pre.sourceCode span.st { color: #4070a0; }
-pre.sourceCode span.co { color: #60a0b0; font-style: italic; }
-pre.sourceCode span.ot { color: #007020; }
-pre.sourceCode span.al { color: red; font-weight: bold; }
-pre.sourceCode span.fu { color: #06287e; }
-pre.sourceCode span.re { }
-pre.sourceCode span.er { color: red; font-weight: bold; }
+.sourceCode span.kw { color: #007020; font-weight: bold; }
+.sourceCode span.dt { color: #902000; }
+.sourceCode span.dv { color: #40a070; }
+.sourceCode span.bn { color: #40a070; }
+.sourceCode span.fl { color: #40a070; }
+.sourceCode span.ch { color: #4070a0; }
+.sourceCode span.st { color: #4070a0; }
+.sourceCode span.co { color: #60a0b0; font-style: italic; }
+.sourceCode span.ot { color: #007020; }
+.sourceCode span.al { color: red; font-weight: bold; }
+.sourceCode span.fu { color: #06287e; }
+.sourceCode span.re { }
+.sourceCode span.er { color: red; font-weight: bold; }


### PR DESCRIPTION
Below is the generated HTML for with line numbers and without line numbers, respectively.

``` html
<!-- Without line numbers -->
<pre class="sourceCode scala">
    <code class="sourceCode scala">
        <span class="kw">trait</span>
        Monad[M[_]]
    </code>
</pre>

<!-- With line numbers -->
<table class="sourceCode scala numberLines">
    <tr class="sourceCode">
        <td class="lineNumbers">
            <pre>1</pre>
        </td>
        <td class="sourceCode">
            <pre>
                <code class="sourceCode scala">
                    <span class="kw">trait</span>
                    Monad[M[_]]
                </code>
            </pre>
        </td>
    </tr>
</table>

```

The markdown used is:

```

~~~~ { .scala }
trait Monad[M[_]]
```

``` .scala .numberLines
trait Monad[M[_]]
```

```

Notice that without line numbers the outer `pre` has a `sourceCode` class whereas with line numbers the `sourceCode` class is only put in `code` and table-related tags.

In the original `syntax.css` file synax highlighting was only triggered if the `kw` and friends tags were within a `pre.sourceCode` - that means it did not trigger with line numbers. This change removes the requirement for the `pre` prefix so that highlighting is triggered with or without line numbers, so long as the code is within *some* `.sourceCode` tag.
```
