### PR TITLE
Moved blog and changed purpose of root

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -54,6 +54,8 @@ this list. This list has no particular ordering.
 - <https://xinitrc.de/>,
   [source](https://github.com/xinitrc/xinitrc.de)
 - <https://darkfox.id.au/>,
+  [source](http://hub.darcs.net/DarkFox/DarkFox-home)
+- <http://blog.darkfox.id.au/>,
   [source](http://hub.darcs.net/DarkFox/DarkFox-blog)
 - <http://nickcharlton.net/>,
   [source](https://github.com/nickcharlton/nickcharlton.net)


### PR DESCRIPTION
I have moved the blog to blog.darkfox.id.au, hosting it on github for performance and darkfox.id.au (optionally with ssl), will include a /blog mirror and be more or less a front-page with my links / stats. (Not setup just yet)
