### PR TITLE
Documentation for the template macros

### DIFF
--- a/src/Hakyll/Web/Template.hs
+++ b/src/Hakyll/Web/Template.hs
@@ -65,7 +65,7 @@
 -- with item @i@, interpolate it, and join the resulting list with
 -- @,@.
 --
--- More concrete example one may consider is the following. Given the
+-- Another concrete example one may consider is the following. Given the
 -- context
 --
 -- > listField "things" (field "thing" (return . itemBody))
@@ -103,7 +103,7 @@
 -- The result of rendering
 --
 -- > <p>
--- >   $partial(\"test.html\")$
+-- >   $partial("test.html")$
 -- > </p>
 --
 -- is the same as the result of rendering
@@ -112,7 +112,7 @@
 -- >   <b>$key$</b>
 -- > </p>
 --
--- That is, @$partial$@ is equivalent to just copying and pasting
+-- That is, calling @$partial$@ is equivalent to just copying and pasting
 -- template code.
 --
 


### PR DESCRIPTION
This could use some improvement, as my style of writing is far from perfect.

I also tried separating the text into sections, like it's done in [pipes](http://hackage.haskell.org/package/pipes-4.0.2/docs/Pipes-Tutorial.html), for example, but the named chunks of documentation thingie for haddock is not working properly and giving me errors.

http://www.haskell.org/haddock/doc/html/ch03s05.html

Maybe this whole thing is worth a tutorial of its own, but IMO this stuff has to be documented somewhere
