### PR TITLE
Added the `pandocCompilerWithTransformM` function

### DIFF
--- a/src/Hakyll/Web/Pandoc.hs
+++ b/src/Hakyll/Web/Pandoc.hs
@@ -118,7 +118,7 @@ pandocCompilerWithTransform ropt wopt f = cached cacheName $
 --------------------------------------------------------------------------------
 -- | Similar to 'pandocCompilerWithTransform', but the transformation
 -- function is monadic. This is useful when you want the pandoc
--- tranfromation to use the 'Compiler' information such as routes,
+-- transformation to use the 'Compiler' information such as routes,
 -- metadata, etc
 pandocCompilerWithTransformM :: ReaderOptions -> WriterOptions
                     -> (Pandoc -> Compiler Pandoc)


### PR DESCRIPTION
Following the [discussion](https://groups.google.com/forum/#!topic/hakyll/XbB20ak441Q) on the mailing list, I've implemented the `pandocCompilerWithTransformM` function, which IMHO might come in handy.

Internal links is just one example. One might want to color, for example, disable syntax highlight based on metadata; or mess with the header levels (something that I wanted to do myself).

If you don't want to clutter code with this, I can wrap this into a tutorial of some sort.

Cheers
-Dan
