### PR TITLE
hakyll check: return exit code of 0 on success

### DIFF
--- a/src/Hakyll/Check.hs
+++ b/src/Hakyll/Check.hs
@@ -57,7 +57,7 @@ data Check = All | InternalLinks
 check :: Configuration -> Verbosity -> Check -> IO ExitCode
 check config verbosity check' = do
     ((), write) <- runChecker checkDestination config verbosity check'
-    return $ if checkerFaulty write >= 0 then ExitFailure 1 else ExitSuccess
+    return $ if checkerFaulty write > 0 then ExitFailure 1 else ExitSuccess
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The old test returns an exit code of 1 whenever the number of
errors is >= 0, which should always be the case. The fix replaces
this with a test whether the number of errors is strictly > 0.
