### PR TITLE
Add www.rohanjain.in as an example for Hakyll 4

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -77,6 +77,8 @@ this list. This list has no particular ordering.
   [source](http://hub.darcs.net/co-dan/website)
 - <http://www.gwern.net/>,
   [source](https://github.com/gwern/gwern.net)
+- <http://www.rohanjain.in/>,
+  [source](https://github.com/crodjer/rohanjain.in)
 
 ## Hakyll 3.X
 
@@ -106,8 +108,6 @@ this list. This list has no particular ordering.
   [source](http://gitorious.org/shakthimaan-blog)
 - <http://www.alfredodinapoli.com/>,
   [source](https://github.com/CharlesStain/alfredodinapoli.com)
-- <http://www.rohanjain.in/>,
-  [source](https://github.com/crodjer/rohanjain.in)
 - <http://datahackermd.com>,
   [source](http://github.com/akshayjshah/datahackermd)
 - <http://michaelxavier.net>,


### PR DESCRIPTION
An example of my site was already present, but this patch is for my recent migration to Hakyll 4.

> Example highlight: Clean URLs, Sitemaps
