### PR TITLE
Fix unixFilter on Windows

### DIFF
--- a/src/Hakyll/Core/UnixFilter.hs
+++ b/src/Hakyll/Core/UnixFilter.hs
@@ -19,7 +19,7 @@ import           System.Exit             (ExitCode (..))
 import           System.IO               (Handle, hClose, hFlush, hGetContents,
                                           hPutStr, hSetEncoding, localeEncoding)
 import           System.Process
-
+import           System.Info
 
 --------------------------------------------------------------------------------
 import           Hakyll.Core.Compiler
@@ -105,8 +105,12 @@ unixFilterIO :: Monoid o
              -> i
              -> IO (o, String, ExitCode)
 unixFilterIO writer reader programName args input = do
+    let pr = if os == "mingw32"
+             then shell $ unwords (programName : args)
+             else proc programName args
+
     (Just inh, Just outh, Just errh, pid) <-
-        createProcess (proc programName args)
+        createProcess pr
                 { std_in  = CreatePipe
                 , std_out = CreatePipe
                 , std_err = CreatePipe


### PR DESCRIPTION
On windows, the 'unixFilter' function used window's 'createProcess'
function to create the external process that will filter some String
input. The problem with this is that it is unable to execute batch
stubs (eg. anything created using 'gem install ...') even if its in
$PATH. Anyways a solution to this issue is to execute the batch file
explicitly using 'cmd /c batchfile' but there is no rational way to know
where said batchfile is on the system. My solution is to detect windows
using the System.Info module and then instead of using 'proc' to create
the process, use 'shell' instead which will be able to execute
everything 'proc' can + batch files.

Inspired by: http://www.blaenkdenum.com/posts/the-switch-to-hakyll/#scss

Signed-off-by: Collin J. Doering rekahsoft@gmail.com
