### PR TITLE
Add duplode.github.io to examples.

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -85,6 +85,8 @@ this list. This list has no particular ordering.
   [source](https://github.com/TikhonJelvis/website)
 - <https://secure.plaimi.net/>,
   [source](https://github.com/plaimi/www)
+- <http://duplode.github.io/>,
+  [source](https://github.com/duplode/duplode.github.io/tree/sources)
 
 ## Hakyll 3.X
 


### PR DESCRIPTION
A much more conventional Hakyll site than my older entry here, scr.stunts.hu. This time the full sources are readily available from the start.
