### PR TITLE
shave sub-second precision off modification time

### DIFF
--- a/src/Hakyll/Core/Provider/Internal.hs
+++ b/src/Hakyll/Core/Provider/Internal.hs
@@ -197,9 +197,14 @@ resourceModificationTime p i =
 fileModificationTime :: FilePath -> IO UTCTime
 fileModificationTime fp = do
 #if MIN_VERSION_directory(1,2,0)
-    getModificationTime fp
+    time <- getModificationTime fp
 #else
     ct <- toCalendarTime =<< getModificationTime fp
     let str = formatCalendarTime defaultTimeLocale "%s" ct
-    return $ readTime defaultTimeLocale "%s" str
+    time <- readTime defaultTimeLocale "%s" str
 #endif
+
+    -- shave sub-second precision
+    let dt = secondsToDiffTime . floor $ utctDayTime time
+
+    return $ time { utctDayTime = dt }


### PR DESCRIPTION
It seems like System.Directory's `getModificationTime` is now providing
sub-second precision if it's available in the underlying system call,
which it seems to be for most systems.

The problem is that when the modification time is stored, the DiffTime,
the number of seconds from midnight, has its sub-second precision
shaved off, effectively becoming 0 the next time it's read.  When a
file is then checked to see if it has been modified, the file is
_always_ deemed to have been modified because this time still includes
the sub-second precision, which will almost always be later in time
than 0, unless of course it happened to be 0 to begin with.

This simply shaves the sub-second precision off of the time returned by
`getModificationTime`, and thus no longer rebuilds every single file
each time any one file is saved.

This closes #250

Update: I rebased some extra changes I made and pushed, doubt anyone will be affected. It added back an unrelated newline I removed from a different section of the file, as well as generalized the fix so that it works in both blocks regardless of the version of directory.
