### PR TITLE
save modification time with sub-second granularity

### DIFF
--- a/src/Hakyll/Core/Provider/Internal.hs
+++ b/src/Hakyll/Core/Provider/Internal.hs
@@ -31,8 +31,7 @@ import           Data.Maybe             (fromMaybe)
 import           Data.Monoid            (mempty)
 import           Data.Set               (Set)
 import qualified Data.Set               as S
-import           Data.Time              (Day (..), UTCTime (..),
-                                         secondsToDiffTime)
+import           Data.Time              (Day (..), UTCTime (..))
 import           Data.Typeable          (Typeable)
 import           System.Directory       (getModificationTime)
 import           System.FilePath        (addExtension, (</>))
@@ -62,11 +61,11 @@ newtype BinaryTime = BinaryTime {unBinaryTime :: UTCTime}
 --------------------------------------------------------------------------------
 instance Binary BinaryTime where
     put (BinaryTime (UTCTime (ModifiedJulianDay d) dt)) =
-        put d >> put (floor dt :: Integer)
+        put d >> put (toRational dt)
 
     get = fmap BinaryTime $ UTCTime
         <$> (ModifiedJulianDay <$> get)
-        <*> (secondsToDiffTime <$> get)
+        <*> (fromRational <$> get)
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Some systems can get the file modification time with sub-second
granularity. However, Hakyll shaves off the sub-seconds, as defined in
the Binary instance of BinaryTime, which poses a problem because when a
file is checked to see if it was modified in `resourceModified`, it
still contains the sub-seconds. This results in a file (almost) always
being considered as having been modified.

Example:
1. First go around, modification time is 3:45.325. This time is saved
   as 3:45.000 (i.e. sub-seconds are shaved off).
2. Second go around, modification time is again read as 3:45.325 and
   compared against the stored time, 3:45.000. 3:45.325 is more recent
   than 3:45.000, so the file is considered to have been modified.

This change prevents the shaving off of sub-seconds. This will naturally
work on systems that don't support sub-second granularity, as that
'field' will simply appear as all zeros.

Note that this is an improvement of PR #251 which shaved off the sub-seconds. This one keeps them.

Closes #250
