### PR TITLE
Allow Emacs org-mode as markup-language in *.org files

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -157,7 +157,7 @@ Library
     network         >= 2.4    && < 2.5,
     old-locale      >= 1.0    && < 1.1,
     old-time        >= 1.0    && < 1.2,
-    pandoc          >= 1.12   && < 1.13,
+    pandoc          >= 1.12.4 && < 1.13,
     pandoc-citeproc >= 0.1    && < 0.4,
     parsec          >= 3.0    && < 3.2,
     process         >= 1.0    && < 1.3,

--- a/src/Hakyll/Web/Pandoc.hs
+++ b/src/Hakyll/Web/Pandoc.hs
@@ -53,6 +53,7 @@ readPandocWith ropt item = fmap (reader ropt (itemFileType item)) item
         LaTeX              -> readLaTeX ro
         LiterateHaskell t' -> reader (addExt ro Ext_literate_haskell) t'
         Markdown           -> readMarkdown ro
+        OrgMode            -> readOrg ro
         Rst                -> readRST ro
         Textile            -> readTextile ro
         _                  -> error $


### PR DESCRIPTION
Bump pandoc's lower version bound and allow OrgMode as a valid `FileType` for posts.
