### PR TITLE
Fix #223: `demoteHeaders` should not modify anything in the document, apart from the headers

### DIFF
--- a/src/Hakyll/Web/Html.hs
+++ b/src/Hakyll/Web/Html.hs
@@ -80,6 +80,7 @@ renderTags' :: [TS.Tag String] -> String
 renderTags' = TS.renderTagsOptions TS.renderOptions
     { TS.optRawTag   = (`elem` ["script", "style"]) . map toLower
     , TS.optMinimize = (`S.member` minimize) . map toLower
+    , TS.optEscape   = id
     }
   where
     -- A list of elements which must be minimized


### PR DESCRIPTION
See #223
