### PR TITLE
add network-uri dependency in .cabal file

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -166,7 +166,8 @@ Library
     regex-tdfa      >= 1.1    && < 1.3,
     tagsoup         >= 0.13.1 && < 0.14,
     text            >= 0.11   && < 1.2,
-    time            >= 1.1    && < 1.5
+    time            >= 1.1    && < 1.5,
+    network-uri
 
   If flag(previewServer)
     Build-depends:


### PR DESCRIPTION
cannot build without newwork-uri in ghc 7.8
