### PR TITLE
add network-uri dependency in .cabal file

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -154,6 +154,7 @@ Library
     filepath        >= 1.0    && < 1.4,
     lrucache        >= 1.1.1  && < 1.2,
     mtl             >= 1      && < 2.3,
+    network-uri     >= 2.6.0,
     network         >= 2.4    && < 2.7,
     old-locale      >= 1.0    && < 1.1,
     old-time        >= 1.0    && < 1.2,


### PR DESCRIPTION
network-uri was split off from the network package in the network-2.6.0 release.
So this will not work for network library whose version is below 2.6.0.