### PR TITLE
matchMetadata for examining metadata when defining rules

### DIFF
--- a/src/Hakyll/Core/Rules.hs
+++ b/src/Hakyll/Core/Rules.hs
@@ -19,6 +19,7 @@
 module Hakyll.Core.Rules
     ( Rules
     , match
+    , matchMetadata
     , create
     , version
     , compile
@@ -125,6 +126,19 @@ match pattern rules = do
     tellPattern pattern
     flush
     ids <- getMatches pattern
+    tellResources ids
+    Rules $ local (setMatches ids) $ unRules $ rules >> flush
+  where
+    setMatches ids env = env {rulesMatches = ids}
+
+
+--------------------------------------------------------------------------------
+matchMetadata :: Pattern -> (Metadata -> Bool) -> Rules () -> Rules ()
+matchMetadata pattern metadataPred rules = do
+    tellPattern pattern
+    flush
+    idsAndMetadata <- getAllMetadata pattern
+    let ids = map fst . filter (metadataPred . snd) $ idsAndMetadata
     tellResources ids
     Rules $ local (setMatches ids) $ unRules $ rules >> flush
   where


### PR DESCRIPTION
Someone else on the mailing list asked last month about using metadata to decide whether or not to compile something when defining `Rules`. This capability would solve a problem for me, too.

I realized all of the tools were already there in the form of the `getAllMetadata` function on the `MonadMetadata` typeclass. This PR just creates an alternative to `match` that also takes a predicate on metadata.