### PR TITLE
Route in template

### DIFF
--- a/src/Hakyll/Core/Util/Parser.hs
+++ b/src/Hakyll/Core/Util/Parser.hs
@@ -22,4 +22,6 @@ metadataKey = do
 
 --------------------------------------------------------------------------------
 reservedKeys :: [String]
-reservedKeys = ["if", "else", "endif", "for", "sep", "endfor", "partial"]
+reservedKeys = [ "if", "else", "endif", "for", "sep", "endfor", "partial"
+               , "route"                                                
+               ]

--- a/src/Hakyll/Web/Template.hs
+++ b/src/Hakyll/Web/Template.hs
@@ -195,6 +195,11 @@ applyTemplate' tpl context x = go tpl
         tpl' <- loadBody (fromFilePath p)
         applyTemplate' tpl' context x
 
+    applyElem (RouteOf i) = getRoute i
+                            >>= maybe err return
+      where err = error $ "Hakyll.Web.Template.applyTemplateWith: "
+                        ++ "identifier"
+                        ++ show i ++ " does not have a valid route"
     getString _ (StringField s) = return s
     getString k (ListField _ _) = fail $
         "Hakyll.Web.Template.applyTemplateWith: expected StringField but " ++

--- a/src/Hakyll/Web/Template/Internal.hs
+++ b/src/Hakyll/Web/Template/Internal.hs
@@ -22,6 +22,7 @@ import qualified Text.Parsec.String      as P
 --------------------------------------------------------------------------------
 import           Hakyll.Core.Util.Parser
 import           Hakyll.Core.Writable
+import           Hakyll.Core.Identifier
 
 
 --------------------------------------------------------------------------------
@@ -46,6 +47,7 @@ data TemplateElement
     | If String Template (Maybe Template)   -- key, then branch, else branch
     | For String Template (Maybe Template)  -- key, body, separator
     | Partial String                        -- filename
+    | RouteOf  Identifier                   -- the route of the identifier
     deriving (Show, Eq, Typeable)
 
 
@@ -57,7 +59,7 @@ instance Binary TemplateElement where
     put (If k t f  )   = putWord8 3 >> put k >> put t >> put f
     put (For k b s)    = putWord8 4 >> put k >> put b >> put s
     put (Partial p)    = putWord8 5 >> put p
-
+    put (RouteOf i)    = putWord8 6 >> put i
     get = getWord8 >>= \tag -> case tag of
         0 -> Chunk <$> get
         1 -> Key   <$> get
@@ -65,6 +67,7 @@ instance Binary TemplateElement where
         3 -> If <$> get <*> get <*> get
         4 -> For <$> get <*> get <*> get
         5 -> Partial <$> get
+        6 -> RouteOf <$> get
         _ -> error $
             "Hakyll.Web.Template.Internal: Error reading cached template"
 


### PR DESCRIPTION
I have added facility to include actual routes in templates. Besides
being of independent interest, it can help in referring to resources
whose actual route changes depending as a function of compilation.
In particular, it is applicable in the context of issue #303.

With is pull request you can refer to actual routes in templates
as

```
$route("index.md")$ 
```

and actually get `index.html` in the output (provided the route of
`index.md` is `index.html`
