### PR TITLE
Relax version lower bounds on network, network-uri

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -86,6 +86,12 @@ Flag checkExternal
   Description: Include external link checking
   Default:     True
 
+-- Needed to support both network-uri<2.6 and >=2.6
+-- See http://hackage.haskell.org/package/network-uri-2.6.0.0
+Flag network-uri
+   description: Get Network.URI from the network-uri package
+   default: True
+
 Library
   Ghc-Options:    -Wall
   Ghc-Prof-Options: -auto-all -caf-all
@@ -155,8 +161,6 @@ Library
     filepath        >= 1.0    && < 1.4,
     lrucache        >= 1.1.1  && < 1.2,
     mtl             >= 1      && < 2.3,
-    network         >= 2.5    && < 2.7,
-    network-uri     >= 2.5    && < 2.7,
     old-locale      >= 1.0    && < 1.1,
     old-time        >= 1.0    && < 1.2,
     pandoc          >= 1.12.4 && < 1.14,
@@ -197,6 +201,15 @@ Library
       http-types   >= 0.7    && < 0.9
     Cpp-options:
       -DCHECK_EXTERNAL
+
+  If flag(network-uri)
+    Build-Depends:
+      network         >= 2.6    && < 2.7,
+      network-uri     >= 2.6    && < 2.7
+  Else
+    Build-Depends:
+      network         >= 2.5    && < 2.6,
+      network-uri     >= 2.5    && < 2.6
 
 Test-suite hakyll-tests
   Type:           exitcode-stdio-1.0
@@ -242,8 +255,6 @@ Test-suite hakyll-tests
     filepath        >= 1.0    && < 1.4,
     lrucache        >= 1.1.1  && < 1.2,
     mtl             >= 1      && < 2.3,
-    network         >= 2.5    && < 2.7,
-    network-uri     >= 2.5    && < 2.7,
     old-locale      >= 1.0    && < 1.1,
     old-time        >= 1.0    && < 1.2,
     pandoc          >= 1.12.4 && < 1.14,
@@ -284,6 +295,15 @@ Test-suite hakyll-tests
       http-types   >= 0.7    && < 0.9
     Cpp-options:
       -DCHECK_EXTERNAL
+
+  If flag(network-uri)
+    Build-Depends:
+      network         >= 2.6    && < 2.7,
+      network-uri     >= 2.6    && < 2.7
+  Else
+    Build-Depends:
+      network         >= 2.5    && < 2.6,
+      network-uri     >= 2.5    && < 2.6
 
 Executable hakyll-init
   Ghc-options:    -Wall


### PR DESCRIPTION
This will allow Hakyll to be included in the current Stackage snapshot.
See: https://github.com/fpco/stackage/pull/331

I have successfully built and run the test suite with `network` 2.5.0.0 and `network-uri` 2.5.0.0
