### PR TITLE
Add convenience function pandocBiblioCompiler.

### DIFF
--- a/src/Hakyll/Web/Pandoc/Biblio.hs
+++ b/src/Hakyll/Web/Pandoc/Biblio.hs
@@ -18,6 +18,7 @@ module Hakyll.Web.Pandoc.Biblio
     , Biblio (..)
     , biblioCompiler
     , readPandocBiblio
+    , pandocBiblioCompiler
     ) where
 
 

--- a/src/Hakyll/Web/Pandoc/Biblio.hs
+++ b/src/Hakyll/Web/Pandoc/Biblio.hs
@@ -7,6 +7,8 @@
 -- refer to these files when you use 'pageReadPandocBiblio'. This function also
 -- takes the reader options for completeness -- you can use
 -- 'defaultHakyllReaderOptions' if you're unsure.
+-- 'pandocBiblioCompiler' is a convenience wrapper which works like 'pandocCompiler',
+-- but also takes paths to compiled bibliography and csl files.
 {-# LANGUAGE Arrows                     #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -21,8 +23,9 @@ module Hakyll.Web.Pandoc.Biblio
 
 --------------------------------------------------------------------------------
 import           Control.Applicative    ((<$>))
-import           Control.Monad          (replicateM)
+import           Control.Monad          (replicateM, liftM)
 import           Data.Binary            (Binary (..))
+import           Data.Default           (def)
 import           Data.Typeable          (Typeable)
 import qualified Text.CSL               as CSL
 import           Text.CSL.Pandoc        (processCites)
@@ -105,3 +108,9 @@ readPandocBiblio ropt csl biblio item = do
 
     return $ fmap (const pandoc') item
 
+pandocBiblioCompiler :: String -> String -> Compiler (Item String)
+pandocBiblioCompiler cslFileName bibFileName = do
+    csl <- load $ fromFilePath cslFileName
+    bib <- load $ fromFilePath bibFileName
+    liftM writePandoc
+        (getResourceBody >>= readPandocBiblio def csl bib)

--- a/src/Hakyll/Web/Pandoc/Biblio.hs
+++ b/src/Hakyll/Web/Pandoc/Biblio.hs
@@ -4,7 +4,7 @@
 -- In order to add a bibliography, you will need a bibliography file (e.g.
 -- @.bib@) and a CSL file (@.csl@). Both need to be compiled with their
 -- respective compilers ('biblioCompiler' and 'cslCompiler'). Then, you can
--- refer to these files when you use 'pageReadPandocBiblio'. This function also
+-- refer to these files when you use 'readPandocBiblio'. This function also
 -- takes the reader options for completeness -- you can use
 -- 'defaultHakyllReaderOptions' if you're unsure.
 -- 'pandocBiblioCompiler' is a convenience wrapper which works like 'pandocCompiler',

--- a/src/Hakyll/Web/Pandoc/Biblio.hs
+++ b/src/Hakyll/Web/Pandoc/Biblio.hs
@@ -109,6 +109,7 @@ readPandocBiblio ropt csl biblio item = do
 
     return $ fmap (const pandoc') item
 
+--------------------------------------------------------------------------------
 pandocBiblioCompiler :: String -> String -> Compiler (Item String)
 pandocBiblioCompiler cslFileName bibFileName = do
     csl <- load $ fromFilePath cslFileName


### PR DESCRIPTION
For rationale, see:

https://github.com/mcmtroffaes/homepage/blob/master/posts/2015-01-09-hakyll-and-bibtex.markdown

The only thing I'm unsure about is passing the csl and bib files as strings: it works, but it may not be the "best" interface. I'm only starting to get to know hakyll's code base so I apologize in advance for my ignorance if I got this wrong.