### PR TITLE
Remove test debug output

### DIFF
--- a/tests/Hakyll/Web/Template/Tests.hs
+++ b/tests/Hakyll/Web/Template/Tests.hs
@@ -55,8 +55,6 @@ case01 = do
     item <- testCompilerDone store provider "example.md"    $
         pandocCompiler >>= applyTemplate (itemBody tpl) testContext
 
-    writeFile "foo" (itemBody item)
-
     out @=? itemBody item
     cleanTestEnv
 


### PR DESCRIPTION
When running hakyll's test suit locally I noticed that a file named "foo" is left in the parent directory of the project after the test suit completes. It looks like this was added for debugging purposes at some point and was accidentally committed.