### PR TITLE
Don't add .cabal extension twice in init

### DIFF
--- a/src/Hakyll/Init.hs
+++ b/src/Hakyll/Init.hs
@@ -72,7 +72,7 @@ makeName dstDir = do
 
 createCabal :: FilePath -> String -> IO ()
 createCabal path name = do
-    writeFile (path ++ ".cabal") $ unlines [
+    writeFile path $ unlines [
         "name:               " ++ name
       , "version:            0.1.0.0"
       , "build-type:         Simple"


### PR DESCRIPTION
Previously, hakyll-init would create the cabal file with a name like
name.cabal.cabal.