### PR TITLE
Return empty field when Listfield has no elements to allow using ()$ …

### DIFF
--- a/src/Hakyll/Web/Template/Context.hs
+++ b/src/Hakyll/Web/Template/Context.hs
@@ -86,8 +86,13 @@ instance Monoid (Context a) where
 
 --------------------------------------------------------------------------------
 field' :: String -> (Item a -> Compiler ContextField) -> Context a
-field' key value = Context $ \k _ i -> if k == key then value i else empty
-
+field' key value = Context $ \k _ i -> if k == key
+    then do
+        v <- value i
+        case v of
+            ListField _ xs -> if (null xs) then empty else return v
+            _ -> return v
+    else empty
 
 --------------------------------------------------------------------------------
 -- | Constructs a new field in the 'Context.'


### PR DESCRIPTION
…around a ()$ block.

This is my first ever Haskell pull request, so apologies for the lack of elegance. This PR is meant to allow using $if()$ blocks surrounding a $for()$ block in templates. It returns empty when a Listfield is empty. This helps for the following (quite common) pattern:
```
$if(list)$
  There is a list!
  $for(list)$
    It contains : $elem$
  $endfor$
$else$
  No list...
$endif$
```