### PR TITLE
Add getItemModificationUTC

### DIFF
--- a/src/Hakyll/Web/Template/Context.hs
+++ b/src/Hakyll/Web/Template/Context.hs
@@ -20,6 +20,7 @@ module Hakyll.Web.Template.Context
     , dateField
     , dateFieldWith
     , getItemUTC
+    , getItemModificationUTC
     , modificationTimeField
     , modificationTimeFieldWith
     , teaserField
@@ -292,6 +293,15 @@ getItemUTC locale id' = do
         , "%B %e, %Y"
         , "%b %d, %Y"
         ]
+
+--------------------------------------------------------------------------------
+-- | fetch the modification time from an file identifier
+getItemModificationUTC :: Identifier        -- ^ Input page
+                       -> Compiler UTCTime  -- ^ UTCTime
+getItemModificationUTC id' = do
+    provider <- compilerProvider <$> compilerAsk
+    let mtime = resourceModificationTime provider id'
+    return mtime
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This function allows to obtain the modification time in UTC which can be useful in introducing a modification-time-related customized field. Personally I need this to convert UTCTime into ZonedTime or LocalTime.
