### PR TITLE
add support for mediawiki

### DIFF
--- a/src/Hakyll/Web/Pandoc.hs
+++ b/src/Hakyll/Web/Pandoc.hs
@@ -63,6 +63,7 @@ readPandocWith ropt item =
         LaTeX              -> readLaTeX ro
         LiterateHaskell t' -> reader (addExt ro Ext_literate_haskell) t'
         Markdown           -> readMarkdown ro
+        MediaWiki          -> readMediaWiki ro
         OrgMode            -> readOrg ro
         Rst                -> readRST ro
         Textile            -> readTextile ro

--- a/src/Hakyll/Web/Pandoc/FileType.hs
+++ b/src/Hakyll/Web/Pandoc/FileType.hs
@@ -27,6 +27,7 @@ data FileType
     | LaTeX
     | LiterateHaskell FileType
     | Markdown
+    | MediaWiki
     | OrgMode
     | PlainText
     | Rst
@@ -39,30 +40,32 @@ data FileType
 fileType :: FilePath -> FileType
 fileType = uncurry fileType' . splitExtension
   where
-    fileType' _ ".css"      = Css
-    fileType' _ ".dbk"      = DocBook
-    fileType' _ ".htm"      = Html
-    fileType' _ ".html"     = Html
-    fileType' f ".lhs"      = LiterateHaskell $ case fileType f of
+    fileType' _ ".css"       = Css
+    fileType' _ ".dbk"       = DocBook
+    fileType' _ ".htm"       = Html
+    fileType' _ ".html"      = Html
+    fileType' f ".lhs"       = LiterateHaskell $ case fileType f of
         -- If no extension is given, default to Markdown + LiterateHaskell
         Binary -> Markdown
         -- Otherwise, LaTeX + LiterateHaskell or whatever the user specified
         x      -> x
-    fileType' _ ".markdown" = Markdown
-    fileType' _ ".md"       = Markdown
-    fileType' _ ".mdn"      = Markdown
-    fileType' _ ".mdown"    = Markdown
-    fileType' _ ".mdwn"     = Markdown
-    fileType' _ ".mkd"      = Markdown
-    fileType' _ ".mkdwn"    = Markdown
-    fileType' _ ".org"      = OrgMode
-    fileType' _ ".page"     = Markdown
-    fileType' _ ".rst"      = Rst
-    fileType' _ ".tex"      = LaTeX
-    fileType' _ ".text"     = PlainText
-    fileType' _ ".textile"  = Textile
-    fileType' _ ".txt"      = PlainText
-    fileType' _ _           = Binary  -- Treat unknown files as binary
+    fileType' _ ".markdown"  = Markdown
+    fileType' _ ".mediawiki" = MediaWiki
+    fileType' _ ".md"        = Markdown
+    fileType' _ ".mdn"       = Markdown
+    fileType' _ ".mdown"     = Markdown
+    fileType' _ ".mdwn"      = Markdown
+    fileType' _ ".mkd"       = Markdown
+    fileType' _ ".mkdwn"     = Markdown
+    fileType' _ ".org"       = OrgMode
+    fileType' _ ".page"      = Markdown
+    fileType' _ ".rst"       = Rst
+    fileType' _ ".tex"       = LaTeX
+    fileType' _ ".text"      = PlainText
+    fileType' _ ".textile"   = Textile
+    fileType' _ ".txt"       = PlainText
+    fileType' _ ".wiki"      = MediaWiki
+    fileType' _ _            = Binary  -- Treat unknown files as binary
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
I choose Pandoc for my doc parser because it supports mediawiki. I'm loving Haskell and prefer writing my posts in *.mediawiki. So I add this support in Hakyll :)