### PR TITLE
Add "poster" as a URL attribute

### DIFF
--- a/src/Hakyll/Web/Html.hs
+++ b/src/Hakyll/Web/Html.hs
@@ -55,7 +55,7 @@ demoteHeaders = withTags $ \tag -> case tag of
 
 --------------------------------------------------------------------------------
 isUrlAttribute :: String -> Bool
-isUrlAttribute = (`elem` ["src", "href", "data"])
+isUrlAttribute = (`elem` ["src", "href", "data", "poster"])
 
 
 --------------------------------------------------------------------------------

--- a/tests/Hakyll/Web/Html/RelativizeUrls/Tests.hs
+++ b/tests/Hakyll/Web/Html/RelativizeUrls/Tests.hs
@@ -22,6 +22,9 @@ tests = testGroup "Hakyll.Web.Html.RelativizeUrls.Tests" $
             relativizeUrlsWith ".." "<a href=\"/foo\">bar</a>"
         , "<img src=\"../../images/lolcat.png\" />" @=?
             relativizeUrlsWith "../.." "<img src=\"/images/lolcat.png\" />"
+        , "<video poster=\"../../images/lolcat.png\"></video>" @=?
+            relativizeUrlsWith "../.."
+                "<video poster=\"/images/lolcat.png\"></video>"
         , "<a href=\"http://haskell.org\">Haskell</a>" @=?
             relativizeUrlsWith "../.."
                 "<a href=\"http://haskell.org\">Haskell</a>"


### PR DESCRIPTION
Similar to #134, this change enables the `poster` attribute of videos to be recognized as a URL and processed using `withURLs`. Here's where it's referenced in the [HTML standard](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-video-poster).

Thanks for maintaining hakyll!