### PR TITLE
Expose templating engine

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -116,6 +116,7 @@ Library
     Hakyll.Web.Tags
     Hakyll.Web.Paginate
     Hakyll.Web.Template
+    Hakyll.Web.Template.Internal
     Hakyll.Web.Template.Context
     Hakyll.Web.Template.List
 
@@ -135,7 +136,6 @@ Library
     Hakyll.Core.Store
     Hakyll.Core.Util.File
     Hakyll.Core.Util.Parser
-    Hakyll.Web.Template.Internal
     Hakyll.Web.Pandoc.Binary
     Paths_hakyll
 


### PR DESCRIPTION
Hello,
I found need to mangle some `Template` contents in my Hakyll website. Everything is quite straightforward, the data structures explain themselves, but… they're not exposed!

I'm not saying that those functions should be exported through `Hakyll`, but I would really like to be able to explicitly `import Hakyll.Web.Template.Internal` into my code. See also [this excellent answer](http://stackoverflow.com/a/9198453/1048572) to the StackOverflow question "*How, why and when to use the “.Internal” modules pattern?*" for detailed argumentation.