### PR TITLE
Item context has precedence before feed context

### DIFF
--- a/src/Hakyll/Web/Feed.hs
+++ b/src/Hakyll/Web/Feed.hs
@@ -76,10 +76,10 @@ renderFeed feedPath itemPath config itemContext items = do
     loadTemplate = fmap readTemplate . readFile <=< getDataFileName
 
     itemContext' = mconcat
-        [ constField "root" (feedRoot config)
+        [ itemContext
+        , constField "root" (feedRoot config)
         , constField "authorName"  (feedAuthorName config)
         , constField "authorEmail" (feedAuthorEmail config)
-        , itemContext
         ]
 
     feedContext = mconcat


### PR DESCRIPTION
The item's author is the item's author, not the feed's owner.