### PR TITLE
Add Snippet expression for snippet includes

### DIFF
--- a/src/Hakyll/Web/Template/Context.hs
+++ b/src/Hakyll/Web/Template/Context.hs
@@ -18,6 +18,7 @@ module Hakyll.Web.Template.Context
     , urlField
     , pathField
     , titleField
+    , snippetField
     , dateField
     , dateFieldWith
     , getItemUTC
@@ -147,6 +148,22 @@ mapContext f (Context c) = Context $ \k a i -> do
             "Hakyll.Web.Template.Context.mapContext: " ++
             "can't map over a ListField!"
 
+--------------------------------------------------------------------------------
+-- | A context that allows snippet inclusion. In processed file, use as:
+--
+-- > ...
+-- > $snippet("path/to/snippet/")$
+-- > ...
+--
+-- The contents of the included file will not be interpolated.
+--
+snippetField :: Context String
+snippetField = functionField "snippet" f
+  where
+    f [contentsPath] _ = loadBody (fromFilePath contentsPath)
+    f _              i = error $
+        "Too many arguments to function 'snippet()' in item " ++
+            show (itemIdentifier i)
 
 --------------------------------------------------------------------------------
 -- | A context that contains (in that order)


### PR DESCRIPTION
I've been using a `$snippet("...")$` for some time, which I find quite useful when I don't want my included files to be processed like templates, as happens with `$partial("...")$`. Typical use case, I want to include an extra Haskell file which contains `$`s and `<$>`s  and most of the file is eaten away. Might be useful to other people as well.

It requires something like this in the rules:

``` haskell
      match "snippet.txt" $ compile getResourceBody
```

instead of

``` haskell
      match "template.txt" $ compile templateCompiler
```



Let me know if I missed an existing solution; also, no hard feelings if this gets rejected. If there's a chance this gets in, I'll update with the doc in `Template/Internal`.