### PR TITLE
Make Travis badge Retina ready

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # hakyll
 
-[![Build Status](https://secure.travis-ci.org/jaspervdj/hakyll.png?branch=master)](http://travis-ci.org/jaspervdj/hakyll)
+[![Build Status](https://img.shields.io/travis/jaspervdj/hakyll.svg)](http://travis-ci.org/jaspervdj/hakyll)
 
 Hakyll is a static site generator library in Haskell. More information
 (including a tutorial) can be found on


### PR DESCRIPTION
Use http://shields.io for a higher quality badge.

Here is a screenshot from my MacBook Pro highlighting the difference (new badge on the right):
<img width="203" alt="screen shot 2016-03-14 at 08 28 03" src="https://cloud.githubusercontent.com/assets/4586410/13736628/c2e55d2e-e9be-11e5-9ac4-65078d8553d6.png">
