### PR TITLE
Recommend Stack in installation/basics tutorials

### DIFF
--- a/web/tutorials/01-installation.markdown
+++ b/web/tutorials/01-installation.markdown
@@ -6,17 +6,13 @@ author: Jasper Van der Jeugt
 Installation
 ------------
 
-Installation is provided using [cabal], and some packages are available for
-different distributions.
+Installation is provided via Hackage, and some packages are available for
+different distributions. For installation from source (i.e. via Hackage),
+[stack] is recommended:
 
-    $ cabal install hakyll
+    $ stack install hakyll
 
-[cabal]: http://www.haskell.org/cabal/
-
-If you have a recent installation of `cabal` and your time is somewhat valuable,
-use:
-
-    $ cabal install -j hakyll
+[stack]: http://www.haskellstack.org/
 
 Linux distro packages:
 
@@ -34,27 +30,21 @@ started:
 This creates a folder `my-site` in the current directory, with some example
 content and a generic configuration.
 
-If `hakyll-init` is not found, you should make sure `$HOME/.cabal/bin` is in
-your `$PATH`.
-
-(If you're on OS X you may not have a bin directory in `$HOME/.cabal`. In this
-case, check `$HOME/Library/Haskell/bin` and put it on your path if you find
-`hakyll-init` there. See [here] for more information on installation paths on
-OS X.)
-
-[here]: http://www.haskell.org/haskellwiki/Mac_OS_X_Common_Installation_Paths
+If `hakyll-init` is not found, you should make sure your stack bin path
+(usually `$HOME/.local/bin`) is in your `$PATH`. You can check your stack local
+bin path by running `stack path --local-bin-path`.
 
 The file `site.hs` holds the configuration of your site, as an executable
 haskell program. We can compile and run it like this:
 
     $ cd my-site
-    $ ghc --make -threaded site.hs
-    $ ./site build
+    $ stack build
+    $ stack exec site build
 
 If you installed `hakyll` with a preview server (this is the default), you can
 now use
 
-    $ ./site watch
+    $ stack exec site watch
 
 and have a look at your site at
 [http://localhost:8000/](http://localhost:8000/).

--- a/web/tutorials/02-basics.markdown
+++ b/web/tutorials/02-basics.markdown
@@ -7,24 +7,24 @@ Building and cleaning
 ---------------------
 
 If you followed along with the previous tutorial, you should now have the
-example site up and running. By running `./site build`, you created two
-directories:
+example site up and running. By running `stack exec site build`, you created
+two directories:
 
 - `_site`, with your site as HTML files, ready to be deployed;
 - `_cache`, which Hakyll uses internally.
 
-`./site clean` removes these directories, and `./site rebuild` performs a
-`clean` and then a `build`.
+`stack exec site clean` removes these directories, and `stack exec site
+rebuild` performs a `clean` and then a `build`.
 
-In general, you want to use `./site build` when you just made changes to the
-contents of your website. If you made important changes to `site.hs`, you need
-to recompile `site.hs` followed by a rebuild:
+In general, you want to use `stack exec site build` when you just made changes
+to the contents of your website. If you made changes to `site.hs`, you need to
+recompile `site.hs` followed by a rebuild:
 
-    ghc --make site.hs
-    ./site rebuild
+    stack build
+    stack exec site rebuild
 
-At this point, feel free to change some files, `./site build` and see what
-happens!
+At this point, feel free to change some files, `stack exec site build` and see
+what happens!
 
 Pages and metadata
 ------------------


### PR DESCRIPTION
See also the mailing list thread: https://groups.google.com/forum/#!topic/hakyll/CR-k5YFi9WA

The only potential downside I can see to doing it this way is that you have to replace `./site <command>` with `stack exec site <command>`, and so this might 'break' other tutorials or materials that refer to Hakyll.