### PR TITLE
Adds itemSetIdentifier to Item.hs and changeIdentifier to Compiler.hs.

### DIFF
--- a/src/Hakyll/Core/Compiler.hs
+++ b/src/Hakyll/Core/Compiler.hs
@@ -6,6 +6,7 @@ module Hakyll.Core.Compiler
     , getUnderlying
     , getUnderlyingExtension
     , makeItem
+    , changeIdentifier
     , getRoute
     , getResourceBody
     , getResourceString
@@ -66,6 +67,11 @@ makeItem :: a -> Compiler (Item a)
 makeItem x = do
     identifier <- getUnderlying
     return $ Item identifier x
+
+
+--------------------------------------------------------------------------------
+changeIdentifier :: Identifier -> Item a -> Compiler (Item a)
+changeIdentifier x item = return $ itemSetIdentifier x item
 
 
 --------------------------------------------------------------------------------

--- a/src/Hakyll/Core/Item.hs
+++ b/src/Hakyll/Core/Item.hs
@@ -5,6 +5,7 @@
 module Hakyll.Core.Item
     ( Item (..)
     , itemSetBody
+    , itemSetIdentifier
     , withItemBody
     ) where
 
@@ -52,6 +53,11 @@ instance Binary a => Binary (Item a) where
 --------------------------------------------------------------------------------
 itemSetBody :: a -> Item b -> Item a
 itemSetBody x (Item i _) = Item i x
+
+
+--------------------------------------------------------------------------------
+itemSetIdentifier :: Identifier -> Item a -> Item a
+itemSetIdentifier x (Item _ i) = Item x i
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Hello @jaspervdj and contributors. :)

This change allows one to change/set the identifier of an Item.

Use case:

Say someone wants to show their most recent post on the home page in its entirety.

```haskell
-- /site.hs
-- ...
  create ["index.html"] $ do
    route idRoute
    compile $ do
      post <- fmap head . recentFirst =<< loadAllSnapshots "posts/*" "content"
      loadAndApplyTemplate "templates/default.html" postCtx post
        >>= relativizeUrls
        >>= changeIdentifier "index.html"
-- ...
```
```html
<!-- "templates/default.html" -->
<html>
  <head>
    <meta property="og:url" content="$url$">
    <title>$title$</title>
  </head>
  <body>
    $date$
    $body
  </body>
</html>
```

This will allow them to create or match a page with a different identifier than the one they wish to load. In this example they are loading say Identifier `posts/yyyy-mm-dd-my-recent-post.markdown` but they output the Identifier `index.html`. 

You can see it in use here https://lettier.github.io rendered and the [source code](https://github.com/lettier/lettier.github.io/blob/hakyll/site.hs#L51). 

Thanks!
