### PR TITLE
src/Hakyll/Web/Paginate.hs: Fix build failure

### DIFF
--- a/src/Hakyll/Web/Paginate.hs
+++ b/src/Hakyll/Web/Paginate.hs
@@ -37,7 +37,7 @@ data Paginate = Paginate
     { paginateMap        :: M.Map PageNumber [Identifier]
     , paginateMakeId     :: PageNumber -> Identifier
     , paginateDependency :: Dependency
-    } deriving (Show)
+    }
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The code tried to generate Show instance for a function.
I don't know where it used to come from but it's not there
anymore. Build fails as:

  [48 of 49] Compiling Hakyll.Web.Paginate ( src/Hakyll/Web/Paginate.hs, dist/build/Hakyll/Web/Paginate.o )

  src/Hakyll/Web/Paginate.hs:40:17:
    No instance for (Show (PageNumber -> Identifier))
      (maybe you haven't applied enough arguments to a function?)
      arising from the second field of ‘Paginate’
        (type ‘PageNumber -> Identifier’)
    Possible fix:
      use a standalone 'deriving instance' declaration,
        so you can specify the instance context yourself
    When deriving the instance for (Show Paginate)

Change drops Show instance as it's not very useful.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>