### PR TITLE
Move to stack for travis CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,20 @@
 language: haskell
 ghc: '7.10'
+branches:
+  only:
+    - master
+cache:
+  directories:
+  - $HOME/.stack
+before_install:
+  - echo "override before_install"
+install:
+  - wget https://github.com/commercialhaskell/stack/releases/download/v1.0.0/stack-1.0.0-linux-x86_64.tar.gz -O stack.gz
+  - tar xvf stack.gz
+  - chmod +x stack-1.0.0-linux-x86_64/stack
+  - stack-1.0.0-linux-x86_64/stack setup
+  - stack-1.0.0-linux-x86_64/stack build
+before_script:
+  - echo "override before_script"
+script:
+  - stack-1.0.0-linux-x86_64/stack test


### PR DESCRIPTION
Slightly hacky travis script.
Here's a log from my test: [here](https://travis-ci.org/sakshamsharma/hakyll/builds/134875314)
Caching is enabled, so it should not build all the dependencies every time.
Also, you need to override some of the travis phases or else it will try to run cabal, which will break during dependency resolution (and is not going to be of any use anyway).