### PR TITLE
Fix rsync command in GH Pages tutorial

### DIFF
--- a/web/tutorials/github-pages-tutorial.md
+++ b/web/tutorials/github-pages-tutorial.md
@@ -168,7 +168,7 @@ git stash pop
 Earlier it was mentioned a flaw is that deleted files will persist in the published site until deleted manually. This is easily overcome by using `rsync` instead of `cp`.
 
 ```
-rsync -a --filter='P _site/' --delete-excluded _site/ .
+rsync -a --filter='P _site/' --filter='P _cache/' --filter='P .git/' --filter='P .gitignore' --delete-excluded _site/ .
 ```
 
 The only drawback this approach has is the requirement that *every* file in your site "go through" Hakyll. Fortunately, in many cases this is not an issue.


### PR DESCRIPTION
This fixes the incorrect `rsync` command, as noted in [this Google Group post](https://groups.google.com/forum/#!topic/hakyll/PBtPQ0PK-20). The new command is more conservative and preserves the `.git` folder and the `.gitignore` file.