### PR TITLE
s/--local-bin-path/--local-bin/

### DIFF
--- a/web/tutorials/01-installation.markdown
+++ b/web/tutorials/01-installation.markdown
@@ -32,7 +32,7 @@ content and a generic configuration.
 
 If `hakyll-init` is not found, you should make sure your stack bin path
 (usually `$HOME/.local/bin`) is in your `$PATH`. You can check your stack local
-bin path by running `stack path --local-bin-path`.
+bin path by running `stack path --local-bin`.
 
 The file `site.hs` holds the configuration of your site, as an executable
 haskell program. We can compile and run it like this:


### PR DESCRIPTION
output of `stack path --local-bin-path`:

```
Run from outside a project, using implicit global project config
Using resolver: lts-6.8 from implicit global project's config file: /home/REDACTED/.stack/global-project/stack.yaml

'--local-bin-path' will be removed in a future release.
Please use '--local-bin' instead.
```