### PR TITLE
stack init is not really optional

### DIFF
--- a/web/tutorials/01-installation.markdown
+++ b/web/tutorials/01-installation.markdown
@@ -38,7 +38,7 @@ The file `site.hs` holds the configuration of your site, as an executable
 haskell program. We can compile and run it like this:
 
     $ cd my-site
-    $ stack init  # To create stack.yaml
+    $ stack init  # creates stack.yaml file based on my-site.cabal
     $ stack build
     $ stack exec site build
 


### PR DESCRIPTION
stack build complains if there is no stack.yaml so the previous comment is misleading for people who don't know what stack init does.