### PR TITLE
Bugfix: CompressCss modified CSS string constants which it should not do

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -223,6 +223,7 @@ Test-suite hakyll-tests
     Hakyll.Core.Store.Tests
     Hakyll.Core.UnixFilter.Tests
     Hakyll.Core.Util.String.Tests
+    Hakyll.Web.CompressCss.Tests
     Hakyll.Web.Html.RelativizeUrls.Tests
     Hakyll.Web.Html.Tests
     Hakyll.Web.Pandoc.FileType.Tests

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -8,14 +8,12 @@ module Hakyll.Web.CompressCss
 
 
 --------------------------------------------------------------------------------
-import           Data.Char               (isSpace)
 import           Data.List               (isPrefixOf)
 
 
 --------------------------------------------------------------------------------
 import           Hakyll.Core.Compiler
 import           Hakyll.Core.Item
-import           Hakyll.Core.Util.String
 
 
 --------------------------------------------------------------------------------

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -39,11 +39,10 @@ compressSeparators str
     | isPrefixOf "'" str = head str : retainConstants compressSeparators "'" (drop 1 str)
     | stripFirst = compressSeparators (drop 1 str)
     | stripSecond = compressSeparators (head str : (drop 2 str))
-    | isPrefixOf ";}" str = '}' : compressSeparators (drop 2 str)
     | otherwise = head str : compressSeparators (drop 1 str)
   where
     prefix p = isPrefixOf p str
-    stripFirst = or $ map prefix ["  ", " {", " }", ";;"]
+    stripFirst = or $ map prefix ["  ", " {", " }", ";;", ";}"]
     stripSecond = or $ map prefix ["{ ", "} ", "; "]
 
 --------------------------------------------------------------------------------

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -37,13 +37,12 @@ compressSeparators [] = []
 compressSeparators str
     | isPrefixOf "\"" str = head str : retainConstants compressSeparators "\"" (drop 1 str)
     | isPrefixOf "'" str = head str : retainConstants compressSeparators "'" (drop 1 str)
-    | stripFirst = compressSeparators (drop 1 str)
+    | stripFirst  = compressSeparators (drop 1 str)
     | stripSecond = compressSeparators (head str : (drop 2 str))
-    | otherwise = head str : compressSeparators (drop 1 str)
+    | otherwise   = head str : compressSeparators (drop 1 str)
   where
-    prefix p = isPrefixOf p str
-    stripFirst = or $ map prefix ["  ", " {", " }", ";;", ";}"]
-    stripSecond = or $ map prefix ["{ ", "} ", "; "]
+    stripFirst  = or $ map (isOfPrefix str) ["  ", " {", " }", ";;", ";}"]
+    stripSecond = or $ map (isOfPrefix str) ["{ ", "} ", "; "]
 
 --------------------------------------------------------------------------------
 -- | Compresses all whitespace.
@@ -56,9 +55,8 @@ compressWhitespace str
     | replaceTwo = compressWhitespace (' ' : (drop 2 str))
     | otherwise = head str : compressWhitespace (drop 1 str)
   where
-    prefix p = isPrefixOf p str
-    replaceOne = or $ map prefix ["\t", "\n", "\r"]
-    replaceTwo = or $ map prefix [" \t", " \n", " \r", "  "]
+    replaceOne = or $ map (isOfPrefix str) ["\t", "\n", "\r"]
+    replaceTwo = or $ map (isOfPrefix str) [" \t", " \n", " \r", "  "]
 
 --------------------------------------------------------------------------------
 -- | Function that strips CSS comments away.
@@ -82,3 +80,8 @@ retainConstants f delim str
     | null str = []
     | isPrefixOf delim str = head str : f (drop 1 str)
     | otherwise = head str : retainConstants f delim (drop 1 str)
+
+--------------------------------------------------------------------------------
+-- | Helper function to determine whether a string is a substring.
+isOfPrefix :: String -> String -> Bool
+isOfPrefix = flip isPrefixOf

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -65,6 +65,8 @@ compressWhitespace str
 stripComments :: String -> String
 stripComments [] = []
 stripComments str
+    | isPrefixOf "\"" str = head str : retainConstants stripComments "\"" (drop 1 str)
+    | isPrefixOf "'" str = head str : retainConstants stripComments "'" (drop 1 str)
     | isPrefixOf "/*" str = stripComments $ eatComments $ drop 2 str
     | otherwise = head str : stripComments (drop 1 str)
   where

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -37,11 +37,17 @@ compressSeparators [] = []
 compressSeparators str
     | isPrefixOf "\"" str = head str : retainConstants compressSeparators "\"" (drop 1 str)
     | isPrefixOf "'" str = head str : retainConstants compressSeparators "'" (drop 1 str)
-    | otherwise =
-        replaceAll "; *}" (const "}") $
-        replaceAll " *([{};]) *" (take 1 . dropWhile isSpace) $
-        replaceAll ";+" (const ";") str
-  where
+    | isPrefixOf "  " str = compressSeparators (drop 1 str)
+    | isPrefixOf " {" str = compressSeparators (drop 1 str)
+    | isPrefixOf " }" str = compressSeparators (drop 1 str)
+    | isPrefixOf " ;" str = compressSeparators (drop 1 str)
+    | isPrefixOf ";;" str = compressSeparators (drop 1 str)
+    | isPrefixOf "{ " str = compressSeparators (head str : (drop 2 str))
+    | isPrefixOf "} " str = compressSeparators (head str : (drop 2 str))
+    | isPrefixOf "; " str = compressSeparators (head str : (drop 2 str))
+    | isPrefixOf ";}" str = '}' : compressSeparators (drop 2 str)
+    | otherwise = head str : compressSeparators (drop 1 str)
+
 
 --------------------------------------------------------------------------------
 -- | Compresses all whitespace.

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -37,17 +37,14 @@ compressSeparators [] = []
 compressSeparators str
     | isPrefixOf "\"" str = head str : retainConstants compressSeparators "\"" (drop 1 str)
     | isPrefixOf "'" str = head str : retainConstants compressSeparators "'" (drop 1 str)
-    | isPrefixOf "  " str = compressSeparators (drop 1 str)
-    | isPrefixOf " {" str = compressSeparators (drop 1 str)
-    | isPrefixOf " }" str = compressSeparators (drop 1 str)
-    | isPrefixOf " ;" str = compressSeparators (drop 1 str)
-    | isPrefixOf ";;" str = compressSeparators (drop 1 str)
-    | isPrefixOf "{ " str = compressSeparators (head str : (drop 2 str))
-    | isPrefixOf "} " str = compressSeparators (head str : (drop 2 str))
-    | isPrefixOf "; " str = compressSeparators (head str : (drop 2 str))
+    | stripFirst = compressSeparators (drop 1 str)
+    | stripSecond = compressSeparators (head str : (drop 2 str))
     | isPrefixOf ";}" str = '}' : compressSeparators (drop 2 str)
     | otherwise = head str : compressSeparators (drop 1 str)
-
+  where
+    prefix p = isPrefixOf p str
+    stripFirst = or $ map prefix ["  ", " {", " }", ";;"]
+    stripSecond = or $ map prefix ["{ ", "} ", "; "]
 
 --------------------------------------------------------------------------------
 -- | Compresses all whitespace.

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -52,7 +52,15 @@ compressWhitespace [] = []
 compressWhitespace str
     | isPrefixOf "\"" str = head str : retainConstants compressWhitespace "\"" (drop 1 str)
     | isPrefixOf "'" str = head str : retainConstants compressWhitespace "'" (drop 1 str)
-    | otherwise = replaceAll "[ \t\n\r]+" (const " ") str
+    | isPrefixOf "\t" str = compressWhitespace (' ' : (drop 1 str))
+    | isPrefixOf "\n" str = compressWhitespace (' ' : (drop 1 str))
+    | isPrefixOf "\r" str = compressWhitespace (' ' : (drop 1 str))
+
+    | isPrefixOf " \t" str = compressWhitespace (' ' : (drop 2 str))
+    | isPrefixOf " \n" str = compressWhitespace (' ' : (drop 2 str))
+    | isPrefixOf " \r" str = compressWhitespace (' ' : (drop 2 str))
+    | isPrefixOf "  " str = compressWhitespace (' ' : (drop 2 str))
+    | otherwise = head str : compressWhitespace (drop 1 str)
 
 
 --------------------------------------------------------------------------------

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -39,8 +39,8 @@ compressSeparators str
     | otherwise   = head str : compressSeparators (drop 1 str)
   where
     isConstant  = or $ map (isOfPrefix str) ["\"", "'"]
-    stripFirst  = or $ map (isOfPrefix str) ["  ", " {", " }", ";;", ";}"]
-    stripSecond = or $ map (isOfPrefix str) ["{ ", "} ", "; "]
+    stripFirst  = or $ map (isOfPrefix str) ["  ", " {", " }", " :", ";;", ";}"]
+    stripSecond = or $ map (isOfPrefix str) ["{ ", "} ", ": ", "; "]
 
 --------------------------------------------------------------------------------
 -- | Compresses all whitespace.

--- a/src/Hakyll/Web/CompressCss.hs
+++ b/src/Hakyll/Web/CompressCss.hs
@@ -52,16 +52,13 @@ compressWhitespace [] = []
 compressWhitespace str
     | isPrefixOf "\"" str = head str : retainConstants compressWhitespace "\"" (drop 1 str)
     | isPrefixOf "'" str = head str : retainConstants compressWhitespace "'" (drop 1 str)
-    | isPrefixOf "\t" str = compressWhitespace (' ' : (drop 1 str))
-    | isPrefixOf "\n" str = compressWhitespace (' ' : (drop 1 str))
-    | isPrefixOf "\r" str = compressWhitespace (' ' : (drop 1 str))
-
-    | isPrefixOf " \t" str = compressWhitespace (' ' : (drop 2 str))
-    | isPrefixOf " \n" str = compressWhitespace (' ' : (drop 2 str))
-    | isPrefixOf " \r" str = compressWhitespace (' ' : (drop 2 str))
-    | isPrefixOf "  " str = compressWhitespace (' ' : (drop 2 str))
+    | replaceOne = compressWhitespace (' ' : (drop 1 str))
+    | replaceTwo = compressWhitespace (' ' : (drop 2 str))
     | otherwise = head str : compressWhitespace (drop 1 str)
-
+  where
+    prefix p = isPrefixOf p str
+    replaceOne = or $ map prefix ["\t", "\n", "\r"]
+    replaceTwo = or $ map prefix [" \t", " \n", " \r", "  "]
 
 --------------------------------------------------------------------------------
 -- | Function that strips CSS comments away.

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -36,6 +36,11 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
           -- but do not compress separators inside of constants
         , "\"  { } ;  \"" @=?
             compressCss "\"  { } ;  \""
+          -- don't compress separators at the start or end of constants
+        , "\" }\"" @=?
+            compressCss "\" }\""
+        , "\"{ \"" @=?
+            compressCss "\"{ \""
           -- don't get irritated by the wrong constant terminator
         , "\"   '   \"" @=?
             compressCss "\"   '   \""

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -33,6 +33,9 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
             compressCss ";   }"
         , "{};" @=?
             compressCss "  {  }  ;  "
+          -- but do not compress separators inside of constants
+        , "\"  { } ;  \"" @=?
+            compressCss "\"  { } ;  \""
         , ";" @=?
             compressCss ";;;;;;;"
 

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -36,6 +36,11 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
           -- but do not compress separators inside of constants
         , "\"  { } ;  \"" @=?
             compressCss "\"  { } ;  \""
+          -- don't get irritated by the wrong constant terminator
+        , "\"   '   \"" @=?
+            compressCss "\"   '   \""
+        , "'   \"   '" @=?
+            compressCss "'   \"   '"
         , ";" @=?
             compressCss ";;;;;;;"
 

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -30,6 +30,8 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
           -- compress separators
         , "}"             @=? compressCss ";   }"
         , "{};"           @=? compressCss "  {  }  ;  "
+          -- compress whitespace even after this curly brace
+        , "}"             @=? compressCss ";   }  "
           -- but do not compress separators inside of constants
         , "\"  { } ;  \"" @=? compressCss "\"  { } ;  \""
           -- don't compress separators at the start or end of constants

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -25,34 +25,23 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
             compressCss " something  \n\t\r  something "
 
           -- strip comments
-        , "" @=?
-            compressCss "/* abc { } ;; \n\t\r */"
+        , ""              @=? compressCss "/* abc { } ;; \n\t\r */"
 
           -- compress separators
-        , "}" @=?
-            compressCss ";   }"
-        , "{};" @=?
-            compressCss "  {  }  ;  "
+        , "}"             @=? compressCss ";   }"
+        , "{};"           @=? compressCss "  {  }  ;  "
           -- but do not compress separators inside of constants
-        , "\"  { } ;  \"" @=?
-            compressCss "\"  { } ;  \""
+        , "\"  { } ;  \"" @=? compressCss "\"  { } ;  \""
           -- don't compress separators at the start or end of constants
-        , "\" }\"" @=?
-            compressCss "\" }\""
-        , "\"{ \"" @=?
-            compressCss "\"{ \""
+        , "\" }\""        @=? compressCss "\" }\""
+        , "\"{ \""        @=? compressCss "\"{ \""
           -- don't get irritated by the wrong constant terminator
-        , "\"   '   \"" @=?
-            compressCss "\"   '   \""
-        , "'   \"   '" @=?
-            compressCss "'   \"   '"
+        , "\"   '   \""   @=? compressCss "\"   '   \""
+        , "'   \"   '"    @=? compressCss "'   \"   '"
           -- don't compress whitespace in constants in the middle of a string
-        , "abc '{ '" @=?
-            compressCss "abc '{ '"
-        , "abc \"{ \"" @=?
-            compressCss "abc \"{ \""
+        , "abc '{ '"      @=? compressCss "abc '{ '"
+        , "abc \"{ \""    @=? compressCss "abc \"{ \""
           -- compress multiple semicolons
-        , ";" @=?
-            compressCss ";;;;;;;"
+        , ";"             @=? compressCss ";;;;;;;"
         ]
     ]

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -23,6 +23,11 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
           -- compress whitespace
           " something something " @=?
             compressCss " something  \n\t\r  something "
+          -- do not compress whitespace in constants
+        , "abc \"  \t\n\r  \" xyz" @=?
+            compressCss "abc \"  \t\n\r  \" xyz"
+        , "abc '  \t\n\r  ' xyz" @=?
+            compressCss "abc '  \t\n\r  ' xyz"
 
           -- strip comments
         , ""              @=? compressCss "/* abc { } ;; \n\t\r */"
@@ -40,7 +45,7 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
           -- don't get irritated by the wrong constant terminator
         , "\"   '   \""   @=? compressCss "\"   '   \""
         , "'   \"   '"    @=? compressCss "'   \"   '"
-          -- don't compress whitespace in constants in the middle of a string
+          -- don't compress whitespace around separators in constants in the middle of a string
         , "abc '{ '"      @=? compressCss "abc '{ '"
         , "abc \"{ \""    @=? compressCss "abc \"{ \""
           -- compress multiple semicolons

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -1,0 +1,43 @@
+--------------------------------------------------------------------------------
+module Hakyll.Web.CompressCss.Tests
+    ( tests
+    ) where
+
+
+--------------------------------------------------------------------------------
+import           Data.Char       (toUpper)
+import           Test.Framework  (Test, testGroup)
+import           Test.HUnit      (assert, (@=?))
+
+
+--------------------------------------------------------------------------------
+import           Hakyll.Web.CompressCss
+import           TestSuite.Util
+
+
+--------------------------------------------------------------------------------
+tests :: Test
+tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
+    [ fromAssertions "compressCss"
+        [ 
+          -- compress whitespace
+          " something something " @=?
+            compressCss " something  \n\t\r  something "
+
+          -- strip comments
+        , "" @=?
+            compressCss "/* abc { } ;; \n\t\r */"
+
+          -- compress separators
+        , "}" @=?
+            compressCss ";   }"
+        , "{};" @=?
+            compressCss "  {  }  ;  "
+        , ";" @=?
+            compressCss ";;;;;;;"
+
+          -- some real-life css
+        , "a:after{content: \" (\" attr(href) \")\"}" @=?
+            compressCss "a:after {  content: \" (\" attr(href) \")\"; }"
+        ]
+    ]

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -46,11 +46,13 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
             compressCss "\"   '   \""
         , "'   \"   '" @=?
             compressCss "'   \"   '"
+          -- don't compress whitespace in constants in the middle of a string
+        , "abc '{ '" @=?
+            compressCss "abc '{ '"
+        , "abc \"{ \"" @=?
+            compressCss "abc \"{ \""
+          -- compress multiple semicolons
         , ";" @=?
             compressCss ";;;;;;;"
-
-          -- some real-life css
-        , "a:after{content: \" (\" attr(href) \")\"}" @=?
-            compressCss "a:after {  content: \" (\" attr(href) \")\"; }"
         ]
     ]

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -51,6 +51,8 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
           -- don't compress whitespace around separators in constants in the middle of a string
         , "abc '{ '"      @=? compressCss "abc '{ '"
         , "abc \"{ \""    @=? compressCss "abc \"{ \""
+          -- compress whitespace after colons
+        , "abc:xyz"       @=? compressCss "abc : xyz"
           -- compress multiple semicolons
         , ";"             @=? compressCss ";;;;;;;"
         ]

--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -30,7 +30,10 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
             compressCss "abc '  \t\n\r  ' xyz"
 
           -- strip comments
-        , ""              @=? compressCss "/* abc { } ;; \n\t\r */"
+        , "before after"  @=? compressCss "before /* abc { } ;; \n\t\r */ after"
+          -- don't strip comments inside constants
+        , "before \"/* abc { } ;; \n\t\r */\" after" 
+                          @=? compressCss "before \"/* abc { } ;; \n\t\r */\" after"
 
           -- compress separators
         , "}"             @=? compressCss ";   }"

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -19,6 +19,7 @@ import qualified Hakyll.Core.Runtime.Tests
 import qualified Hakyll.Core.Store.Tests
 import qualified Hakyll.Core.UnixFilter.Tests
 import qualified Hakyll.Core.Util.String.Tests
+import qualified Hakyll.Web.CompressCss.Tests
 import qualified Hakyll.Web.Html.RelativizeUrls.Tests
 import qualified Hakyll.Web.Html.Tests
 import qualified Hakyll.Web.Pandoc.FileType.Tests
@@ -39,6 +40,7 @@ main = defaultMain
     , Hakyll.Core.Store.Tests.tests
     , Hakyll.Core.UnixFilter.Tests.tests
     , Hakyll.Core.Util.String.Tests.tests
+    , Hakyll.Web.CompressCss.Tests.tests
     , Hakyll.Web.Html.RelativizeUrls.Tests.tests
     , Hakyll.Web.Html.Tests.tests
     , Hakyll.Web.Pandoc.FileType.Tests.tests


### PR DESCRIPTION
CompressCss applied compressions (e.g. removal of whitespace) to CSS string constants. But those constants should retain their contents in the compressed CSS.

I've added some tests to demonstrate the behaviour, and I fixed the code. My new code is still rather verbose, which I think can be improved. I'm open to suggestions!