### PR TITLE
prettyPrintParseException was introduced in yaml-0.8.11

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -268,7 +268,7 @@ Test-suite hakyll-tests
     time-locale-compat   >= 0.1    && < 0.2,
     unordered-containers >= 0.2    && < 0.3,
     vector               >= 0.11   && < 0.12,
-    yaml                 >= 0.8    && < 0.9,
+    yaml                 >= 0.8.11    && < 0.9,
     optparse-applicative >= 0.12   && < 0.13
 
   If flag(previewServer)


### PR DESCRIPTION
hakyll does not build with earlier versions of yaml that didn't provide `prettyPrintParseException`.