### PR TITLE
Fix integer fields in YAML metadata

### DIFF
--- a/src/Data/Yaml/Extended.hs
+++ b/src/Data/Yaml/Extended.hs
@@ -13,6 +13,8 @@ toString :: Value -> Maybe String
 toString (String t)     = Just (T.unpack t)
 toString (Bool   True)  = Just "true"
 toString (Bool   False) = Just "false"
+-- | Make sure that numeric fields containing integer numbers are shown as
+-- | integers (i.e., "42" instead of "42.0").
 toString (Number d) | isInteger d = Just (formatScientific Fixed (Just 0) d)
                     | otherwise   = Just (show d)
 toString _              = Nothing

--- a/src/Data/Yaml/Extended.hs
+++ b/src/Data/Yaml/Extended.hs
@@ -7,12 +7,14 @@ module Data.Yaml.Extended
 import qualified Data.Text   as T
 import qualified Data.Vector as V
 import           Data.Yaml
+import           Data.Scientific
 
 toString :: Value -> Maybe String
 toString (String t)     = Just (T.unpack t)
 toString (Bool   True)  = Just "true"
 toString (Bool   False) = Just "false"
-toString (Number d)     = Just (show d)
+toString (Number d) | isInteger d = Just (formatScientific Fixed (Just 0) d)
+                    | otherwise   = Just (show d)
 toString _              = Nothing
 
 toList :: Value -> Maybe [Value]

--- a/tests/Hakyll/Web/Template/Tests.hs
+++ b/tests/Hakyll/Web/Template/Tests.hs
@@ -29,6 +29,7 @@ tests :: TestTree
 tests = testGroup "Hakyll.Core.Template.Tests" $ concat
     [ [ testCase "case01" $ test ("template.html.out", "template.html", "example.md")
       , testCase "case02" $ test ("strip.html.out", "strip.html", "example.md")
+      , testCase "case03" $ test ("just-meta.html.out", "just-meta.html", "example.md")
       , testCase "applyJoinTemplateList" testApplyJoinTemplateList
       ]
 

--- a/tests/data/example.md.metadata
+++ b/tests/data/example.md.metadata
@@ -1,3 +1,5 @@
 external: External data
 date: 2012-10-22 14:35:24
 subblog: food
+intfield: 42
+numfield: 3.14

--- a/tests/data/just-meta.html
+++ b/tests/data/just-meta.html
@@ -1,0 +1,7 @@
+<pre>
+external: {$external$}
+date: {$date$}
+subblog: {$subblog$}
+intfield: {$intfield$}
+numfield: {$numfield$}
+</pre>

--- a/tests/data/just-meta.html.out
+++ b/tests/data/just-meta.html.out
@@ -1,0 +1,7 @@
+<pre>
+external: {External data}
+date: {2012-10-22 14:35:24}
+subblog: {food}
+intfield: {42}
+numfield: {3.14}
+</pre>


### PR DESCRIPTION
If a numeric field contains an integer number, it should be shown
as an integer number.  Without this patch, the field:

    answer = 42

would be shown as "42.0".  Before the introduction of YAML in
metadata, this was treated as a string and therefore shown as
just "42".  This patch reinstates the older (and IMHO correct)
behavior.