### PR TITLE
Remove `argumatronic.org` from examples.

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -168,8 +168,6 @@ directly with the default Hakyll site.
   [source](https://github.com/beerendlauwers/HaskAnything)
 - <https://www.brandonstil.es/>,
   [source](https://github.com/stilesb/brandonstil.es)
-- <http://argumatronic.com/>,
-  [source](https://gitlab.com/GinBaby/argumatronic/tree/master)
 
 ## Hakyll 3.X
 


### PR DESCRIPTION
This woman is a well-known supporter of neo-Nazi ideologies, and has
expressed quite a willingness to shoot anyone who disagrees with
her. I don't know that she's a great example of someone a project
should be associated with.

For example, this thread where she and a friend support buying ammo
for any FPer because, well, obviously they believe all FPers are Nazis
who might get punched or something:

![ammo-for-fp](https://cloud.githubusercontent.com/assets/6731207/23886729/31621688-084b-11e7-9c50-d38c5a6ec2ca.png)

![argumatronic-006](https://cloud.githubusercontent.com/assets/6731207/23886905/6df63a42-084c-11e7-9115-290202550fe3.png)

And of course she proudly contributed to giving yet another platform
to White Supremacy. And, as we've seen from the uptick in
violence (more like a groundswell) by White Supremacists even before
the U.S. election, I think that there's really no question that paying
for someone with that ideology to speak is the same kind of enablement
that makes the truly violent people feel much more comfortable in
exercising that violence, which she and hers already have expressed a
willingness to do in order to defend their right to support violence.