### PR TITLE
Tighten the dependency on pandoc-citeproc.

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -169,7 +169,7 @@ Library
     network              >= 2.6    && < 2.7,
     network-uri          >= 2.6    && < 2.7,
     pandoc               >= 1.14   && < 1.20,
-    pandoc-citeproc      >= 0.4    && < 0.11,
+    pandoc-citeproc      >= 0.4    && < 0.10.5,
     parsec               >= 3.0    && < 3.2,
     process              >= 1.0    && < 1.6,
     random               >= 1.0    && < 1.2,


### PR DESCRIPTION
0.10.5 added a new type `CLabel` to `Text.CSL.Reference`, which broke the orphan instance in `Web.Pandoc.Binary`.

Note also that according to PVP a client that defines an orphan instance **must** depend on the *minor* version of the package defining the type.