### PR TITLE
Expose settings for the preview server

### DIFF
--- a/src/Hakyll/Commands.hs
+++ b/src/Hakyll/Commands.hs
@@ -120,8 +120,8 @@ rebuild conf logger rules =
 server :: Configuration -> Logger -> String -> Int -> IO ()
 #ifdef PREVIEW_SERVER
 server conf logger host port = do
-    let destination = destinationDirectory conf
-    staticServer logger destination host port
+    let settings = previewSettings conf $ destinationDirectory conf
+    staticServer logger settings host port
 #else
 server _ _ _ _ = previewServerDisabled
 #endif

--- a/src/Hakyll/Core/Configuration.hs
+++ b/src/Hakyll/Core/Configuration.hs
@@ -10,6 +10,7 @@ module Hakyll.Core.Configuration
 --------------------------------------------------------------------------------
 import           Data.Default     (Default (..))
 import           Data.List        (isPrefixOf, isSuffixOf)
+import qualified Network.Wai.Application.Static as Static
 import           System.Directory (canonicalizePath)
 import           System.Exit      (ExitCode)
 import           System.FilePath  (isAbsolute, normalise, takeFileName)
@@ -78,6 +79,9 @@ data Configuration = Configuration
       -- One can also override the port as a command line argument:
       -- ./site preview -p 1234
       previewPort          :: Int
+      -- | Override other settings used by the preview server. Default is
+      -- 'Static.defaultFileServerSettings'.
+    , previewSettings      :: FilePath -> Static.StaticSettings
     }
 
 --------------------------------------------------------------------------------
@@ -98,6 +102,7 @@ defaultConfiguration = Configuration
     , inMemoryCache        = True
     , previewHost          = "127.0.0.1"
     , previewPort          = 8000
+    , previewSettings      = Static.defaultFileServerSettings
     }
   where
     ignoreFile' path

--- a/src/Hakyll/Preview/Server.hs
+++ b/src/Hakyll/Preview/Server.hs
@@ -18,14 +18,13 @@ import           Hakyll.Core.Logger    (Logger)
 import qualified Hakyll.Core.Logger    as Logger
 
 staticServer :: Logger               -- ^ Logger
-             -> FilePath             -- ^ Directory to serve
+             -> Static.StaticSettings -- ^ Static file server settings
              -> String               -- ^ Host to bind on
              -> Int                  -- ^ Port to listen on
              -> IO ()                -- ^ Blocks forever
-staticServer logger directory host port = do
+staticServer logger settings host port = do
     Logger.header logger $ "Listening on http://" ++ host ++ ":" ++ show port
-    Warp.runSettings warpSettings $
-        Static.staticApp (Static.defaultFileServerSettings directory)
+    Warp.runSettings warpSettings $ Static.staticApp settings
   where
     warpSettings = Warp.setLogger noLog
         $ Warp.setHost (fromString host)


### PR DESCRIPTION
This enables customization of the settings used by the preview server,
for example to implement URL rewriting.

My particular use case is to mimic the `tryFiles` setting in nginx to
add an extension when looking for a matching file. Then the URL can be
`/projects/web` and it will match a file called `projects/web.html` --
a nice clean URL that doesn't require lots of subdirectories and every
file being called `index.html`.

(This change doesn't implement that feature directly as part of
Hakyll, it just exposes the settings to enable building features like
it in your `site.hs`.)