### PR TITLE
Add spyhop.cafe to example sites

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -182,6 +182,8 @@ directly with the default Hakyll site.
   [source](https://github.com/sillybytes/sillybytes)
 - <https://falconpilot.github.io/>
   [source](https://github.com/FalconPilot/falconpilot.github.io)
+- <http://spyhop.cafe/>
+  [source](https://github.com/thunky-monk/spyhop-cafe)
 
 ## Hakyll 3.X
 


### PR DESCRIPTION
Hey, thanks for maintaining Hakyll :)

I'd like to add this site to the list of examples. There's nothing notable about this site except that it doesn't use Hakyll templating. Instead it uses [Lucid](https://hackage.haskell.org/package/lucid) to define the HTML and passes along the metadata in a record type.

Cheers,
Aaron