### PR TITLE
Fix compression of calc() in CSS

### DIFF
--- a/tests/Hakyll/Web/CompressCss/Tests.hs
+++ b/tests/Hakyll/Web/CompressCss/Tests.hs
@@ -42,6 +42,8 @@ tests = testGroup "Hakyll.Web.CompressCss.Tests" $ concat
         , "a>b"           @=? compressCss "a > b"
         , "a+b"           @=? compressCss "a + b"
         , "a!b"           @=? compressCss "a ! b"
+          -- compress calc()
+        , "calc(1px + 100%/(5 + 3) - (3px + 2px)*5)" @=? compressCss "calc( 1px + 100% / ( 5 +  3) - calc( 3px + 2px ) * 5 )"
           -- compress whitespace even after this curly brace
         , "}"             @=? compressCss ";   }  "
           -- but do not compress separators inside of constants


### PR DESCRIPTION
According to Mozilla Developer Network, “The + and - operators must always be surrounded by whitespace.”.