### PR TITLE
Export `Check` type

### DIFF
--- a/lib/Hakyll/Commands.hs
+++ b/lib/Hakyll/Commands.hs
@@ -2,7 +2,8 @@
 -- | Implementation of Hakyll commands: build, preview...
 {-# LANGUAGE CPP #-}
 module Hakyll.Commands
-    ( build
+    ( Check(..)
+    , build
     , check
     , clean
     , preview
@@ -18,6 +19,7 @@ import           Control.Concurrent
 import           System.Exit                (ExitCode, exitWith)
 
 --------------------------------------------------------------------------------
+import           Hakyll.Check               (Check(..))
 import qualified Hakyll.Check               as Check
 import           Hakyll.Core.Configuration
 import           Hakyll.Core.Logger         (Logger)


### PR DESCRIPTION
# Motivation
I'd like to add tests to my website and run them before it's deployed. Hakyll provides a link checker out-of-the-box that I'd like to integrate in my tests in a clean way.

# Current situation
The `check` function is exported but on of its parameters - the `Check` type - is not exported making it impossible to use it outside the Hakyll project. This means that the only way to run it right now is to ask an external tool like `stack` to run it and then somehow parse the resulting output to check that no error occurred. An sample implementation of this approach is available [here](https://github.com/futtetennista/futtetennista.github.com/commit/154211c694d6dbb6c36d5223cc57e745d8a51857). I think it's safe to affirm that this approach is far from being ideal.

# Proposed change
Export the `Check` type and its type constructors so that the `check` function can be called from outside the Hakyll project.