### PR TITLE
stack.yaml: configure nix options

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -14,3 +14,8 @@ flags:
 
 packages:
   - '.'
+
+nix:
+  enable: false
+  packages:
+    - zlib


### PR DESCRIPTION
This allows `stack --nix build` to work.