### PR TITLE
Added -threaded to ghc-options. pthread link errors on linux with GHC 8.2

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -226,7 +226,7 @@ Test-suite hakyll-tests
   Type:             exitcode-stdio-1.0
   Hs-source-dirs:   tests
   Main-is:          TestSuite.hs
-  Ghc-options:      -Wall
+  Ghc-options:      -Wall -threaded
   Default-language: Haskell2010
 
   Other-modules:
@@ -315,7 +315,7 @@ Test-suite hakyll-tests
 
 Executable hakyll-init
   Main-is:          Init.hs
-  Ghc-options:      -Wall
+  Ghc-options:      -Wall -threaded
   Hs-source-dirs:   src
   Default-language: Haskell2010
 
@@ -330,7 +330,7 @@ Executable hakyll-init
 
 Executable hakyll-website
   Main-is:          site.hs
-  Ghc-options:      -Wall
+  Ghc-options:      -Wall -threaded
   Hs-source-dirs:   web
   Default-language: Haskell2010
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,7 @@ packages:
 extra-deps:
   - hslua-module-text-0.1.2
   - skylighting-0.5
-  - pandoc-citeproc-0.12.1.1
+  - pandoc-citeproc-0.12.2.2
 
 nix:
   enable: false


### PR DESCRIPTION
Similar to these issues:

- [pthread link errors on linux with GHC 8.2 #4130](https://github.com/jgm/pandoc/issues/4130)
- [Error building on Ubuntu 16 #311](https://github.com/jgm/pandoc-citeproc/issues/311)