### PR TITLE
Load a template from a local files if present then fallback to embedded files

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -56,10 +56,6 @@ Data-files:
   example/index.html
   example/about.rst
   example/contact.markdown
-  templates/atom-item.xml
-  templates/atom.xml
-  templates/rss-item.xml
-  templates/rss.xml
 
 Extra-source-files:
   CHANGELOG.md
@@ -190,7 +186,8 @@ Library
     unordered-containers >= 0.2      && < 0.3,
     vector               >= 0.11     && < 0.13,
     yaml                 >= 0.8.11   && < 0.9,
-    optparse-applicative >= 0.12     && < 0.15
+    optparse-applicative >= 0.12     && < 0.15,
+    file-embed           >= 0.0.10.1 && < 0.0.11
 
   If flag(previewServer)
     Build-depends:

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -73,6 +73,10 @@ Extra-source-files:
   tests/data/strip.html.out
   tests/data/template.html
   tests/data/template.html.out
+  data/templates/atom-item.xml
+  data/templates/atom.xml
+  data/templates/rss-item.xml
+  data/templates/rss.xml
 
 Source-Repository head
   Type:     git

--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -35,6 +35,7 @@ import           Hakyll.Web.Template.List
 
 --------------------------------------------------------------------------------
 import           Paths_hakyll
+import           System.Directory (doesFileExist)
 
 
 --------------------------------------------------------------------------------
@@ -73,9 +74,10 @@ renderFeed feedPath itemPath config itemContext items = do
     applyFilter tr str = return $ fmap tr str
     protectCDATA :: String -> String
     protectCDATA = replaceAll "]]>" (const "]]&gt;")
-    -- Auxiliary: load a template from a datafile
+    -- Auxiliary: load a template from a local file if present or from a datafile
     loadTemplate path = do
-        file <- compilerUnsafeIO $ getDataFileName path
+        isLocal <- compilerUnsafeIO $ doesFileExist path
+        file <- compilerUnsafeIO $ if isLocal then return path else getDataFileName path
         unsafeReadTemplateFile file
 
     itemContext' = mconcat

--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 --------------------------------------------------------------------------------
 -- | A Module that allows easy rendering of RSS feeds.
 --
@@ -25,7 +27,6 @@ module Hakyll.Web.Feed
 
 --------------------------------------------------------------------------------
 import           Hakyll.Core.Compiler
-import           Hakyll.Core.Compiler.Internal
 import           Hakyll.Core.Item
 import           Hakyll.Core.Util.String (replaceAll)
 import           Hakyll.Web.Template
@@ -34,8 +35,22 @@ import           Hakyll.Web.Template.List
 
 
 --------------------------------------------------------------------------------
-import           Paths_hakyll
-import           System.Directory (doesFileExist)
+import           Data.ByteString.Char8 (unpack)
+import           Data.FileEmbed (embedFile)
+
+
+--------------------------------------------------------------------------------
+rssTemplate :: String
+rssTemplate = unpack $(embedFile "data/templates/rss.xml")
+
+rssItemTemplate :: String
+rssItemTemplate = unpack $(embedFile "data/templates/rss-item.xml")
+
+atomTemplate :: String
+atomTemplate = unpack $(embedFile "data/templates/atom.xml")
+
+atomItemTemplate :: String
+atomItemTemplate = unpack $(embedFile "data/templates/atom-item.xml")
 
 
 --------------------------------------------------------------------------------
@@ -57,14 +72,16 @@ data FeedConfiguration = FeedConfiguration
 --------------------------------------------------------------------------------
 -- | Abstract function to render any feed.
 renderFeed :: FilePath                -- ^ Feed template
+           -> String                  -- ^ Default feed template
            -> FilePath                -- ^ Item template
+           -> String                  -- ^ Default item template
            -> FeedConfiguration       -- ^ Feed configuration
            -> Context String          -- ^ Context for the items
            -> [Item String]           -- ^ Input items
            -> Compiler (Item String)  -- ^ Resulting item
-renderFeed feedPath itemPath config itemContext items = do
-    feedTpl <- loadTemplate feedPath
-    itemTpl <- loadTemplate itemPath
+renderFeed feedPath defFeed itemPath defItem config itemContext items = do
+    feedTpl <- unsafeReadTemplateFile' feedPath defFeed
+    itemTpl <- unsafeReadTemplateFile' itemPath defItem
 
     protectedItems <- mapM (applyFilter protectCDATA) items
     body <- makeItem =<< applyTemplateList itemTpl itemContext' protectedItems
@@ -74,11 +91,6 @@ renderFeed feedPath itemPath config itemContext items = do
     applyFilter tr str = return $ fmap tr str
     protectCDATA :: String -> String
     protectCDATA = replaceAll "]]>" (const "]]&gt;")
-    -- Auxiliary: load a template from a local file if present or from a datafile
-    loadTemplate path = do
-        isLocal <- compilerUnsafeIO $ doesFileExist path
-        file <- compilerUnsafeIO $ if isLocal then return path else getDataFileName path
-        unsafeReadTemplateFile file
 
     itemContext' = mconcat
         [ itemContext
@@ -115,7 +127,7 @@ renderRss :: FeedConfiguration       -- ^ Feed configuration
           -> [Item String]           -- ^ Feed items
           -> Compiler (Item String)  -- ^ Resulting feed
 renderRss config context = renderFeed
-    "templates/rss.xml" "templates/rss-item.xml" config
+    "templates/rss.xml" rssTemplate "templates/rss-item.xml" rssItemTemplate config
     (makeItemContext "%a, %d %b %Y %H:%M:%S UT" context)
 
 
@@ -126,7 +138,7 @@ renderAtom :: FeedConfiguration       -- ^ Feed configuration
            -> [Item String]           -- ^ Feed items
            -> Compiler (Item String)  -- ^ Resulting feed
 renderAtom config context = renderFeed
-    "templates/atom.xml" "templates/atom-item.xml" config
+    "templates/atom.xml" atomTemplate "templates/atom-item.xml" atomItemTemplate config
     (makeItemContext "%Y-%m-%dT%H:%M:%SZ" context)
 
 

--- a/lib/Hakyll/Web/Template.hs
+++ b/lib/Hakyll/Web/Template.hs
@@ -140,6 +140,8 @@
 --
 module Hakyll.Web.Template
     ( Template
+    , template
+    , readTemplateElemsFile
     , templateBodyCompiler
     , templateCompiler
     , applyTemplate
@@ -147,7 +149,6 @@ module Hakyll.Web.Template
     , applyAsTemplate
     , readTemplate
     , unsafeReadTemplateFile
-    , unsafeReadTemplateFile'
     ) where
 
 

--- a/lib/Hakyll/Web/Template.hs
+++ b/lib/Hakyll/Web/Template.hs
@@ -141,7 +141,7 @@
 module Hakyll.Web.Template
     ( Template
     , template
-    , readTemplateElemsFile
+    , readTemplateElems
     , templateBodyCompiler
     , templateCompiler
     , applyTemplate

--- a/lib/Hakyll/Web/Template.hs
+++ b/lib/Hakyll/Web/Template.hs
@@ -147,6 +147,7 @@ module Hakyll.Web.Template
     , applyAsTemplate
     , readTemplate
     , unsafeReadTemplateFile
+    , unsafeReadTemplateFile'
     ) where
 
 

--- a/lib/Hakyll/Web/Template/Internal.hs
+++ b/lib/Hakyll/Web/Template/Internal.hs
@@ -11,6 +11,7 @@ module Hakyll.Web.Template.Internal
     , applyAsTemplate
     , readTemplate
     , unsafeReadTemplateFile
+    , unsafeReadTemplateFile'
 
     , module Hakyll.Web.Template.Internal.Element
     , module Hakyll.Web.Template.Internal.Trim
@@ -24,6 +25,7 @@ import           Data.List                            (intercalate)
 import           Data.Typeable                        (Typeable)
 import           GHC.Exts                             (IsString (..))
 import           Prelude                              hiding (id)
+import           System.Directory                     (doesFileExist)
 
 
 --------------------------------------------------------------------------------
@@ -201,3 +203,12 @@ unsafeReadTemplateFile file = do
     tpl <- unsafeCompiler $ readFile file
     pure $ template $ readTemplateElemsFile file tpl
 
+
+--------------------------------------------------------------------------------
+unsafeReadTemplateFile' :: FilePath -> String -> Compiler Template
+unsafeReadTemplateFile' file defValue = do
+    tpl <- unsafeCompiler $ do
+      isLocal <- doesFileExist file
+      if isLocal then readFile file
+      else return defValue
+    pure $ template $ readTemplateElemsFile file tpl

--- a/lib/Hakyll/Web/Template/Internal.hs
+++ b/lib/Hakyll/Web/Template/Internal.hs
@@ -11,7 +11,6 @@ module Hakyll.Web.Template.Internal
     , applyAsTemplate
     , readTemplate
     , unsafeReadTemplateFile
-    , unsafeReadTemplateFile'
 
     , module Hakyll.Web.Template.Internal.Element
     , module Hakyll.Web.Template.Internal.Trim
@@ -25,7 +24,6 @@ import           Data.List                            (intercalate)
 import           Data.Typeable                        (Typeable)
 import           GHC.Exts                             (IsString (..))
 import           Prelude                              hiding (id)
-import           System.Directory                     (doesFileExist)
 
 
 --------------------------------------------------------------------------------
@@ -201,14 +199,4 @@ applyAsTemplate context item =
 unsafeReadTemplateFile :: FilePath -> Compiler Template
 unsafeReadTemplateFile file = do
     tpl <- unsafeCompiler $ readFile file
-    pure $ template $ readTemplateElemsFile file tpl
-
-
---------------------------------------------------------------------------------
-unsafeReadTemplateFile' :: FilePath -> String -> Compiler Template
-unsafeReadTemplateFile' file defValue = do
-    tpl <- unsafeCompiler $ do
-      isLocal <- doesFileExist file
-      if isLocal then readFile file
-      else return defValue
     pure $ template $ readTemplateElemsFile file tpl


### PR DESCRIPTION
This is very useful when hakyll is used to build statically linked binary in which case it would make sense to have a way to provide template files from a current working directory instead of fetching it from `data-files` that is very specific to where haskell code was built (e.g. build server).

I have elaborated on this a bit in my blog post [here](http://www.kuznero.com/posts/haskell/building-statically-linked-binaries.html#data-files-in-dependencies).