### PR TITLE
Various dependency bumps

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -160,7 +160,7 @@ Library
 
   Build-Depends:
     base                 >= 4.8      && < 5,
-    binary               >= 0.5      && < 0.9,
+    binary               >= 0.5      && < 0.10,
     blaze-html           >= 0.5      && < 0.10,
     blaze-markup         >= 0.5.1    && < 0.9,
     bytestring           >= 0.9      && < 0.11,
@@ -174,8 +174,8 @@ Library
     mtl                  >= 1        && < 2.3,
     network              >= 2.6      && < 2.7,
     network-uri          >= 2.6      && < 2.7,
-    pandoc               >= 2.0.5    && < 2.1,
-    pandoc-citeproc      >= 0.12.1.1 && < 0.13,
+    pandoc               >= 2.0.5    && < 2.2,
+    pandoc-citeproc      >= 0.13     && < 0.14,
     parsec               >= 3.0      && < 3.2,
     process              >= 1.6      && < 1.7,
     random               >= 1.0      && < 1.2,
@@ -198,9 +198,8 @@ Library
       wai             >= 3.2   && < 3.3,
       warp            >= 3.2   && < 3.3,
       wai-app-static  >= 3.1   && < 3.2,
-      http-types      >= 0.9   && < 0.10,
-      fsnotify        >= 0.2   && < 0.3,
-      system-filepath >= 0.4.6 && <= 0.5
+      http-types      >= 0.9   && < 0.12,
+      fsnotify        >= 0.2   && < 0.3
     Cpp-options:
       -DPREVIEW_SERVER
     Other-modules:
@@ -209,8 +208,7 @@ Library
 
   If flag(watchServer)
     Build-depends:
-      fsnotify        >= 0.2   && < 0.3,
-      system-filepath >= 0.4.6 && <= 0.5
+      fsnotify        >= 0.2   && < 0.3
     Cpp-options:
       -DWATCH_SERVER
     Other-modules:
@@ -219,7 +217,7 @@ Library
   If flag(checkExternal)
     Build-depends:
       http-conduit >= 2.2    && < 2.3,
-      http-types   >= 0.7    && < 0.10
+      http-types   >= 0.7    && < 0.12
     Cpp-options:
       -DCHECK_EXTERNAL
 
@@ -251,13 +249,13 @@ Test-suite hakyll-tests
 
   Build-Depends:
     hakyll,
-    QuickCheck                 >= 2.8  && < 2.11,
-    tasty                      >= 0.11 && < 0.12,
-    tasty-hunit                >= 0.9  && < 0.10,
+    QuickCheck                 >= 2.8  && < 2.12,
+    tasty                      >= 0.11 && < 1.1,
+    tasty-hunit                >= 0.9  && < 0.11,
     tasty-quickcheck           >= 0.8  && < 0.10,
     -- Copy pasted from hakyll dependencies:
     base                 >= 4.8      && < 5,
-    binary               >= 0.5      && < 0.9,
+    binary               >= 0.5      && < 0.10,
     blaze-html           >= 0.5      && < 0.10,
     blaze-markup         >= 0.5.1    && < 0.9,
     bytestring           >= 0.9      && < 0.11,
@@ -271,8 +269,8 @@ Test-suite hakyll-tests
     mtl                  >= 1        && < 2.3,
     network              >= 2.6      && < 2.7,
     network-uri          >= 2.6      && < 2.7,
-    pandoc               >= 2.0.5    && < 2.1,
-    pandoc-citeproc      >= 0.12.1.1 && < 0.13,
+    pandoc               >= 2.0.5    && < 2.2,
+    pandoc-citeproc      >= 0.13     && < 0.14,
     parsec               >= 3.0      && < 3.2,
     process              >= 1.6      && < 1.7,
     random               >= 1.0      && < 1.2,
@@ -294,23 +292,21 @@ Test-suite hakyll-tests
       wai             >= 3.2   && < 3.3,
       warp            >= 3.2   && < 3.3,
       wai-app-static  >= 3.1   && < 3.2,
-      http-types      >= 0.9   && < 0.10,
-      fsnotify        >= 0.2   && < 0.3,
-      system-filepath >= 0.4.6 && <= 0.5
+      http-types      >= 0.9   && < 0.12,
+      fsnotify        >= 0.2   && < 0.3
     Cpp-options:
       -DPREVIEW_SERVER
 
   If flag(watchServer)
     Build-depends:
-      fsnotify        >= 0.2   && < 0.3,
-      system-filepath >= 0.4.6 && <= 0.5
+      fsnotify        >= 0.2   && < 0.3
     Cpp-options:
       -DWATCH_SERVER
 
   If flag(checkExternal)
     Build-depends:
       http-conduit >= 2.2    && < 2.3,
-      http-types   >= 0.7    && < 0.10
+      http-types   >= 0.7    && < 0.12
     Cpp-options:
       -DCHECK_EXTERNAL
 
@@ -345,4 +341,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.0.5 && < 2.1
+    pandoc    >= 2.0.5 && < 2.2

--- a/lib/Hakyll/Web/Pandoc/Biblio.hs
+++ b/lib/Hakyll/Web/Pandoc/Biblio.hs
@@ -84,7 +84,10 @@ instance Writable Biblio where
 biblioCompiler :: Compiler (Item Biblio)
 biblioCompiler = do
     filePath <- toFilePath <$> getUnderlying
-    makeItem =<< unsafeCompiler (Biblio <$> CSL.readBiblioFile filePath)
+    makeItem =<< unsafeCompiler (Biblio <$> CSL.readBiblioFile idpred filePath)
+  where
+    -- This is a filter on citations.  We include all citations.
+    idpred = const True
 
 
 --------------------------------------------------------------------------------

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2017-12-14
+resolver: nightly-2018-01-15
 extra-package-dbs: []
 
 flags:
@@ -11,10 +11,16 @@ flags:
 packages:
   - '.'
 
+allow-newer: True
+
 extra-deps:
-  - hslua-module-text-0.1.2
-  - skylighting-0.5
-  - pandoc-citeproc-0.12.2.2
+  - 'binary-0.9.0.0'
+  - 'http-types-0.11'
+  - 'pandoc-2.1'
+  - 'pandoc-citeproc-0.13'
+  - 'QuickCheck-2.11.3'
+  - 'tasty-1.0.0.1'
+  - 'tasty-hunit-0.10.0.1'
 
 nix:
   enable: false

--- a/tests/Hakyll/Core/Provider/Tests.hs
+++ b/tests/Hakyll/Core/Provider/Tests.hs
@@ -9,7 +9,7 @@ module Hakyll.Core.Provider.Tests
 import           Hakyll.Core.Metadata
 import           Hakyll.Core.Provider
 import           Test.Tasty           (TestTree, testGroup)
-import           Test.Tasty.HUnit     (Assertion, assert, testCase, (@=?))
+import           Test.Tasty.HUnit     (Assertion, testCase, (@=?))
 import           TestSuite.Util
 
 
@@ -25,7 +25,7 @@ case01 :: Assertion
 case01 = do
     store    <- newTestStore
     provider <- newTestProvider store
-    assert $ resourceExists provider "example.md"
+    True @=? resourceExists provider "example.md"
 
     metadata <- resourceMetadata provider "example.md"
     Just "An example"    @=? lookupString "title"    metadata

--- a/tests/Hakyll/Core/Rules/Tests.hs
+++ b/tests/Hakyll/Core/Rules/Tests.hs
@@ -20,7 +20,7 @@ import           Hakyll.Core.Rules.Internal
 import           Hakyll.Web.Pandoc
 import           System.FilePath                ((</>))
 import           Test.Tasty                     (TestTree, testGroup)
-import           Test.Tasty.HUnit               (Assertion, assert, (@=?))
+import           Test.Tasty.HUnit               (Assertion, (@=?))
 import           TestSuite.Util
 
 
@@ -50,7 +50,7 @@ case01 = do
     checkRoute "example.mv1"     (sv "mv1" "example.md")
     checkRoute "example.mv2"     (sv "mv2" "example.md")
     checkRoute "food/example.md" (sv "metadataMatch" "example.md")
-    readIORef ioref >>= assert
+    readIORef ioref >>= (True @=?)
     cleanTestEnv
   where
     sv g     = setVersion (Just g)

--- a/tests/Hakyll/Core/Store/Tests.hs
+++ b/tests/Hakyll/Core/Store/Tests.hs
@@ -63,11 +63,11 @@ wrongType = do
     -- Store a string and try to fetch an int
     Store.set store ["foo", "bar"] ("qux" :: String)
     value <- Store.get store ["foo", "bar"] :: IO (Store.Result Int)
-    H.assert $ case value of
-        Store.WrongType e t ->
-            e == typeOf (undefined :: Int) &&
-            t == typeOf (undefined :: String)
-        _                   -> False
+    case value of
+        Store.WrongType e t -> do
+            typeOf (undefined :: Int)    H.@=? e
+            typeOf (undefined :: String) H.@=? t
+        _ -> H.assertFailure "Expecting WrongType"
     cleanTestEnv
 
 
@@ -78,6 +78,6 @@ isMembertest = do
     Store.set store ["foo", "bar"] ("qux" :: String)
     good <- Store.isMember store ["foo", "bar"]
     bad  <- Store.isMember store ["foo", "baz"]
-    H.assert good
-    H.assert (not bad)
+    True  H.@=? good
+    False H.@=? bad
     cleanTestEnv

--- a/tests/Hakyll/Core/UnixFilter/Tests.hs
+++ b/tests/Hakyll/Core/UnixFilter/Tests.hs
@@ -39,7 +39,7 @@ unixFilterRev = do
     provider <- newTestProvider store
     output   <- testCompilerDone store provider testMarkdown compiler
     expected <- testCompilerDone store provider testMarkdown getResourceString
-    H.assert $ rev (itemBody expected) == lines (itemBody output)
+    rev (itemBody expected) H.@=? lines (itemBody output)
     cleanTestEnv
   where
     compiler = getResourceString >>= withItemBody (unixFilter "rev" [])
@@ -52,9 +52,9 @@ unixFilterFalse = do
     store    <- newTestStore
     provider <- newTestProvider store
     result   <- testCompiler store provider testMarkdown compiler
-    H.assert $ case result of
-        CompilerError es -> any ("exit code" `isInfixOf`) es
-        _                -> False
+    case result of
+        CompilerError es -> True H.@=? any ("exit code" `isInfixOf`) es
+        _                -> H.assertFailure "Expecting CompilerError"
     cleanTestEnv
   where
     compiler = getResourceString >>= withItemBody (unixFilter "false" [])
@@ -66,9 +66,9 @@ unixFilterError = do
     store    <- newTestStore
     provider <- newTestProvider store
     result   <- testCompiler store provider testMarkdown compiler
-    H.assert $ case result of
-        CompilerError es -> any ("invalid option" `isInfixOf`) es
-        _                -> False
+    case result of
+        CompilerError es -> True H.@=? any ("invalid option" `isInfixOf`) es
+        _                -> H.assertFailure "Expecting CompilerError"
     cleanTestEnv
   where
     compiler = getResourceString >>= withItemBody (unixFilter "head" ["-#"])

--- a/tests/Hakyll/Web/Html/Tests.hs
+++ b/tests/Hakyll/Web/Html/Tests.hs
@@ -7,7 +7,7 @@ module Hakyll.Web.Html.Tests
 --------------------------------------------------------------------------------
 import           Data.Char        (toUpper)
 import           Test.Tasty       (TestTree, testGroup)
-import           Test.Tasty.HUnit (assert, (@=?))
+import           Test.Tasty.HUnit ((@=?))
 
 
 --------------------------------------------------------------------------------
@@ -64,11 +64,11 @@ tests = testGroup "Hakyll.Web.Html.Tests" $ concat
         ]
 
     , fromAssertions "isExternal"
-        [ assert (isExternal "http://reddit.com")
-        , assert (isExternal "https://mail.google.com")
-        , assert (isExternal "//ajax.googleapis.com")
-        , assert (not (isExternal "../header.png"))
-        , assert (not (isExternal "/foo/index.html"))
+        [ True  @=? isExternal "http://reddit.com"
+        , True  @=? isExternal "https://mail.google.com"
+        , True  @=? isExternal "//ajax.googleapis.com"
+        , False @=? isExternal "../header.png"
+        , False @=? isExternal "/foo/index.html"
         ]
 
     , fromAssertions "stripTags"


### PR DESCRIPTION
- Bump binary to 0.9
- Bump pandoc to 2.1
- Bump pandoc-citeproc to 0.13
- Bump http-types to 0.11
- Bump QuickCheck to 2.11
- Bump tasty to 1.0
- Bump tasty-hunit to 0.10
- Remove system-filepath dependency