### PR TITLE
Update tutorial for YAML object metadata

### DIFF
--- a/web/tutorials/04-compilers.markdown
+++ b/web/tutorials/04-compilers.markdown
@@ -92,7 +92,7 @@ And `$title$` like this:
 titleContext :: Context a
 titleContext = field "title" $ \item -> do
     metadata <- getMetadata (itemIdentifier item)
-    return $ fromMaybe "No title" $ M.lookup "title" metadata
+    return $ fromMaybe "No title" $ lookupString "title" metadata
 ```
 
 And compose them using the `Monoid` instance:


### PR DESCRIPTION
Since version 4.8 `Metadata` is no longer a Map but a YAML object. (see #225)

The compilers tutorial is adapted to use `lookupString` instead of `Map.lookup`.