### PR TITLE
Use makeRelativeToProject with embedFile (for stack ghci)

### DIFF
--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -35,7 +35,7 @@ import           Hakyll.Web.Template.List
 
 
 --------------------------------------------------------------------------------
-import           Data.FileEmbed              (embedFile)
+import           Data.FileEmbed              (makeRelativeToProject, embedFile)
 import qualified Data.Text                   as T
 import qualified Data.Text.Encoding          as T
 
@@ -43,20 +43,19 @@ import qualified Data.Text.Encoding          as T
 --------------------------------------------------------------------------------
 rssTemplate :: String
 rssTemplate = T.unpack $
-    T.decodeUtf8 $(embedFile "data/templates/rss.xml")
+    T.decodeUtf8 $(makeRelativeToProject "data/templates/rss.xml" >>= embedFile)
 
 rssItemTemplate :: String
 rssItemTemplate = T.unpack $
-    T.decodeUtf8 $(embedFile "data/templates/rss-item.xml")
+    T.decodeUtf8 $(makeRelativeToProject "data/templates/rss-item.xml" >>= embedFile)
 
 atomTemplate :: String
 atomTemplate = T.unpack $
-    T.decodeUtf8 $(embedFile "data/templates/atom.xml")
+    T.decodeUtf8 $(makeRelativeToProject "data/templates/atom.xml" >>= embedFile)
 
 atomItemTemplate :: String
 atomItemTemplate = T.unpack $
-    T.decodeUtf8 $(embedFile "data/templates/atom-item.xml")
-
+    T.decodeUtf8 $(makeRelativeToProject "data/templates/atom-item.xml" >>= embedFile)
 
 --------------------------------------------------------------------------------
 -- | This is a data structure to keep the configuration of a feed.


### PR DESCRIPTION
The 'makeRelativeToProject' allows usage of package relative filepaths, even if
ghc's working dir is not the package directory.  This enables me to have a
locally modified version of hakyll as part of my stack project, and run "stack
ghci" to load my hakyll project + hakyll all into one ghci session.