### PR TITLE
Use Data.ByteString.Base16.encode.

### DIFF
--- a/lib/Hakyll/Core/Store.hs
+++ b/lib/Hakyll/Core/Store.hs
@@ -27,6 +27,7 @@ import           Data.Maybe           (isJust)
 import qualified Data.Text            as T
 import qualified Data.Text.Encoding   as T
 import           Data.Typeable        (TypeRep, Typeable, cast, typeOf)
+import           Numeric              (showHex)
 import           System.Directory     (createDirectoryIfMissing)
 import           System.Directory     (doesFileExist, removeFile)
 import           System.FilePath      ((</>))
@@ -193,5 +194,8 @@ deleteFile = handle (\(_ :: IOException) -> return ()) . removeFile
 --------------------------------------------------------------------------------
 -- | Mostly meant for internal usage
 hash :: [String] -> String
-hash = concatMap (printf "%02x") . B.unpack .
-    MD5.hash . T.encodeUtf8 . T.pack . intercalate "/"
+hash = toHex . B.unpack . MD5.hash . T.encodeUtf8 . T.pack . intercalate "/"
+  where
+    toHex [] = ""
+    toHex (x : xs) | x < 16 = '0' : showHex x (toHex xs)
+                   | otherwise = showHex x (toHex xs)


### PR DESCRIPTION
I have a somewhat pages lookup-heavy site (lots of structure with autogenerated TOCs), and profiling shows `hash` is responsible for 40% of MUT time and roughly 45% of allocations. Replacing `concatMap` over `printf` with a bytestring-operating base16 encoding makes `hash` go away from the first lines of the profile and reduces site build time from ~10 seconds to 5 seconds for me (which looks like a nice improvement!).

I guess the names of the cached data are changed with this modification, but that's a matter of `site clean` (or `site rebuild`) anyway.

Hopefully you don't mind an additional dependency on base16-bytestring!