### PR TITLE
Fix 'fromFilePath' for compatibility with Windows

### DIFF
--- a/lib/Hakyll/Core/Identifier.hs
+++ b/lib/Hakyll/Core/Identifier.hs
@@ -21,7 +21,8 @@ module Hakyll.Core.Identifier
 --------------------------------------------------------------------------------
 import           Control.DeepSeq     (NFData (..))
 import           Data.List           (intercalate)
-import           System.FilePath     (dropTrailingPathSeparator, splitPath)
+import           System.FilePath     (dropTrailingPathSeparator, splitPath,
+                                      pathSeparator)
 
 
 --------------------------------------------------------------------------------
@@ -64,7 +65,7 @@ instance Show Identifier where
 -- | Parse an identifier from a string
 fromFilePath :: String -> Identifier
 fromFilePath = Identifier Nothing .
-    intercalate "/" . filter (not . null) . split'
+    intercalate [pathSeparator] . filter (not . null) . split'
   where
     split' = map dropTrailingPathSeparator . splitPath
 


### PR DESCRIPTION
Like #645, in windows, this raises a problem:

```
Initialising...
  Creating store...
  Creating provider...
  Running rules...
Checking for out-of-date items
Compiling
  [ERROR] docs-pre\articles/coq_pattern_match.rst: hGetContents: invalid argument
                           ^
                           +- here (expected '\')
```