### PR TITLE
Adds support for rendering feeds with custom templates

### DIFF
--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -22,6 +22,8 @@ module Hakyll.Web.Feed
     ( FeedConfiguration (..)
     , renderRss
     , renderAtom
+    , renderRssWithTemplates
+    , renderAtomWithTemplates
     ) where
 
 
@@ -126,14 +128,40 @@ renderFeed defFeed defItem config itemContext items = do
 
 
 --------------------------------------------------------------------------------
+-- | Render an RSS feed using given templates with a number of items.
+renderRssWithTemplates ::
+       String                  -- ^ Feed template
+    -> String                  -- ^ Item template
+    -> FeedConfiguration       -- ^ Feed configuration
+    -> Context String          -- ^ Item context
+    -> [Item String]           -- ^ Feed items
+    -> Compiler (Item String)  -- ^ Resulting feed
+renderRssWithTemplates feedTemplate itemTemplate config context = renderFeed
+    feedTemplate itemTemplate config
+    (makeItemContext "%a, %d %b %Y %H:%M:%S UT" context)
+
+
+--------------------------------------------------------------------------------
+-- | Render an Atom feed using given templates with a number of items.
+renderAtomWithTemplates ::
+       String                  -- ^ Feed template
+    -> String                  -- ^ Item template
+    -> FeedConfiguration       -- ^ Feed configuration
+    -> Context String          -- ^ Item context
+    -> [Item String]           -- ^ Feed items
+    -> Compiler (Item String)  -- ^ Resulting feed
+renderAtomWithTemplates feedTemplate itemTemplate config context = renderFeed
+    feedTemplate itemTemplate config
+    (makeItemContext "%Y-%m-%dT%H:%M:%SZ" context)
+
+
+--------------------------------------------------------------------------------
 -- | Render an RSS feed with a number of items.
 renderRss :: FeedConfiguration       -- ^ Feed configuration
           -> Context String          -- ^ Item context
           -> [Item String]           -- ^ Feed items
           -> Compiler (Item String)  -- ^ Resulting feed
-renderRss config context = renderFeed
-    rssTemplate rssItemTemplate config
-    (makeItemContext "%a, %d %b %Y %H:%M:%S UT" context)
+renderRss = renderRssWithTemplates rssTemplate rssItemTemplate
 
 
 --------------------------------------------------------------------------------
@@ -142,9 +170,7 @@ renderAtom :: FeedConfiguration       -- ^ Feed configuration
            -> Context String          -- ^ Item context
            -> [Item String]           -- ^ Feed items
            -> Compiler (Item String)  -- ^ Resulting feed
-renderAtom config context = renderFeed
-    atomTemplate atomItemTemplate config
-    (makeItemContext "%Y-%m-%dT%H:%M:%SZ" context)
+renderAtom = renderAtomWithTemplates atomTemplate atomItemTemplate
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
An example usage is as follows:

```haskell
customRenderAtom :: FeedConfiguration -> Context String -> [Item String] -> Compiler (Item String)
customRenderAtom config context items = do
  atomTemplate     <- unsafeCompiler $ readFile "templates/atom.xml"
  atomItemTemplate <- unsafeCompiler $ readFile "templates/atom-item.xml"
  renderAtomWithTemplates atomTemplate atomItemTemplate config context items
```

This should also fix #625 as people will be able to add custom templates with tags.