### PR TITLE
Fix about file path for compatibility with Windows

### DIFF
--- a/lib/Hakyll/Core/Identifier.hs
+++ b/lib/Hakyll/Core/Identifier.hs
@@ -21,7 +21,8 @@ module Hakyll.Core.Identifier
 --------------------------------------------------------------------------------
 import           Control.DeepSeq     (NFData (..))
 import           Data.List           (intercalate)
-import           System.FilePath     (dropTrailingPathSeparator, splitPath)
+import           System.FilePath     (dropTrailingPathSeparator, splitPath,
+                                      pathSeparator)
 
 
 --------------------------------------------------------------------------------
@@ -72,7 +73,9 @@ fromFilePath = Identifier Nothing .
 --------------------------------------------------------------------------------
 -- | Convert an identifier to a relative 'FilePath'
 toFilePath :: Identifier -> FilePath
-toFilePath = identifierPath
+toFilePath = intercalate [pathSeparator] . split' . identifierPath
+  where
+    split' = map dropTrailingPathSeparator . splitPath
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -39,24 +39,29 @@ import           Hakyll.Web.Template.List
 
 --------------------------------------------------------------------------------
 import           Data.FileEmbed              (makeRelativeToProject)
+import           System.FilePath             ((</>))
 
 
 --------------------------------------------------------------------------------
 rssTemplate :: Template
 rssTemplate =
-    $(makeRelativeToProject "data/templates/rss.xml" >>= embedTemplate)
+    $(makeRelativeToProject ("data" </> "templates" </> "rss.xml")
+        >>= embedTemplate)
 
 rssItemTemplate :: Template
 rssItemTemplate =
-    $(makeRelativeToProject "data/templates/rss-item.xml" >>= embedTemplate)
+    $(makeRelativeToProject ("data" </> "templates" </> "rss-item.xml")
+        >>= embedTemplate)
 
 atomTemplate :: Template
 atomTemplate =
-    $(makeRelativeToProject "data/templates/atom.xml" >>= embedTemplate)
+    $(makeRelativeToProject ("data" </> "templates" </> "atom.xml")
+        >>= embedTemplate)
 
 atomItemTemplate :: Template
 atomItemTemplate =
-    $(makeRelativeToProject "data/templates/atom-item.xml" >>= embedTemplate)
+    $(makeRelativeToProject ("data" </> "templates" </> "atom-item.xml")
+        >>= embedTemplate)
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes two bugs related to path separator.

1. The 'makeRelativeToProject' reads files according to those filepaths. Therefore, compilation will fail if its path separator are wrong.
2. When converting to the 'Identifier', incorrect path separator are mixed, which causes file loading to fail.

See also: #640, #644, #645, #649