### PR TITLE
Drop extension when parsing dates in filepaths

### DIFF
--- a/lib/Hakyll/Web/Template/Context.hs
+++ b/lib/Hakyll/Web/Template/Context.hs
@@ -50,7 +50,7 @@ import           Hakyll.Core.Metadata
 import           Hakyll.Core.Provider
 import           Hakyll.Core.Util.String       (needlePrefix, splitAll)
 import           Hakyll.Web.Html
-import           System.FilePath               (splitDirectories, takeBaseName)
+import           System.FilePath               (splitDirectories, takeBaseName, dropExtension)
 
 
 --------------------------------------------------------------------------------
@@ -300,7 +300,7 @@ getItemUTC :: MonadMetadata m
 getItemUTC locale id' = do
     metadata <- getMetadata id'
     let tryField k fmt = lookupString k metadata >>= parseTime' fmt
-        paths          = splitDirectories $ toFilePath id'
+        paths          = splitDirectories $ (dropExtension . toFilePath) id'
 
     maybe empty' return $ msum $
         [tryField "published" fmt | fmt <- formats] ++

--- a/tests/Hakyll/Web/Template/Context/Tests.hs
+++ b/tests/Hakyll/Web/Template/Context/Tests.hs
@@ -41,6 +41,10 @@ testDateField = do
             dateField "date" "%B %e, %Y"
     date2 @=? "August 26, 2010"
 
+    date3 <- testContextDone store provider
+        "posts/2018-09-26.md" "date" $
+            dateField "date" "%B %e, %Y"
+    date3 @=? "September 26, 2018"
     cleanTestEnv
 
 

--- a/tests/data/posts/2018-09-26.md
+++ b/tests/data/posts/2018-09-26.md
@@ -1,0 +1,1 @@
+Something happened today.


### PR DESCRIPTION
Drop the file extension when parsing the date from the filepath of a resource.

This fixes a bug in which Hakyll is unable to parse the date from a filepath and throws an error when the file has a name like `posts/2018-09-26.md` because the extension becomes part of the day value. 