### PR TITLE
change ignoreFile to receive a complete filepath

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -1,5 +1,5 @@
 Name:    hakyll
-Version: 4.12.4.0
+Version: 4.12.5.0
 
 Synopsis: A static website compiler library
 Description:

--- a/lib/Hakyll/Core/Util/File.hs
+++ b/lib/Hakyll/Core/Util/File.hs
@@ -30,7 +30,7 @@ getRecursiveContents :: (FilePath -> IO Bool)  -- ^ Ignore this file/directory
 getRecursiveContents ignore top = go ""
   where
     isProper x
-        | x `elem` [".", ".."] = return False
+        | (takeBaseName x) `elem` [".", ".."] = return False
         | otherwise            = not <$> ignore x
 
     go dir     = do

--- a/lib/Hakyll/Core/Util/File.hs
+++ b/lib/Hakyll/Core/Util/File.hs
@@ -12,7 +12,7 @@ import           Control.Monad       (filterM, forM, when)
 import           System.Directory    (createDirectoryIfMissing,
                                       doesDirectoryExist, getDirectoryContents,
                                       removeDirectoryRecursive)
-import           System.FilePath     (takeBaseName,takeDirectory, (</>))
+import           System.FilePath     (takeDirectory, (</>))
 
 
 --------------------------------------------------------------------------------
@@ -29,16 +29,16 @@ getRecursiveContents :: (FilePath -> IO Bool)  -- ^ Ignore this file/directory
                      -> IO [FilePath]          -- ^ List of files found
 getRecursiveContents ignore top = go ""
   where
-    isProper x
-        | (takeBaseName x) `elem` [".", ".."] = return False
-        | otherwise            = not <$> ignore x
+    isProper dir x
+        | x `elem` [".", ".."] = return False
+        | otherwise            = not <$> ignore (dir </> x)
 
     go dir     = do
         dirExists <- doesDirectoryExist (top </> dir)
         if not dirExists
             then return []
             else do
-                names <- filterM (isProper . (dir </>)) =<< getDirectoryContents (top </> dir)
+                names <- filterM (isProper dir) =<< getDirectoryContents (top </> dir)
                 paths <- forM names $ \name -> do
                     let rel = dir </> name
                     isDirectory <- doesDirectoryExist (top </> rel)

--- a/lib/Hakyll/Core/Util/File.hs
+++ b/lib/Hakyll/Core/Util/File.hs
@@ -12,7 +12,7 @@ import           Control.Monad       (filterM, forM, when)
 import           System.Directory    (createDirectoryIfMissing,
                                       doesDirectoryExist, getDirectoryContents,
                                       removeDirectoryRecursive)
-import           System.FilePath     (takeDirectory, (</>))
+import           System.FilePath     (takeBaseName,takeDirectory, (</>))
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Core/Util/File.hs
+++ b/lib/Hakyll/Core/Util/File.hs
@@ -38,7 +38,7 @@ getRecursiveContents ignore top = go ""
         if not dirExists
             then return []
             else do
-                names <- filterM (isProper . (top </> dir </>)) =<< getDirectoryContents (top </> dir)
+                names <- filterM (isProper . (dir </>)) =<< getDirectoryContents (top </> dir)
                 paths <- forM names $ \name -> do
                     let rel = dir </> name
                     isDirectory <- doesDirectoryExist (top </> rel)

--- a/lib/Hakyll/Core/Util/File.hs
+++ b/lib/Hakyll/Core/Util/File.hs
@@ -38,7 +38,7 @@ getRecursiveContents ignore top = go ""
         if not dirExists
             then return []
             else do
-                names <- filterM isProper =<< getDirectoryContents (top </> dir)
+                names <- filterM (isProper . (top </> dir </>)) =<< getDirectoryContents (top </> dir)
                 paths <- forM names $ \name -> do
                     let rel = dir </> name
                     isDirectory <- doesDirectoryExist (top </> rel)


### PR DESCRIPTION
Hi,

When reading the [documentation](http://hackage.haskell.org/package/hakyll-4.12.4.0/docs/Hakyll-Core-Configuration.html), I was under the impression that the ignoreFile function should receive a complete FilePath from the providerDirectory, but it was actually only receiving the file name -- due to the behavior of the getRecursiveContents function.
I have made a simple extension to getRecursiveContents to mitigate this.
I am not sure if this was intentional or not; if that was the case, than I think that it would deserve a remark in the docs.

Cheers,
hugo