### PR TITLE
Corrected assertion in unixFilterError test. Fixes #669

### DIFF
--- a/tests/Hakyll/Core/UnixFilter/Tests.hs
+++ b/tests/Hakyll/Core/UnixFilter/Tests.hs
@@ -67,7 +67,7 @@ unixFilterError = do
     provider <- newTestProvider store
     result   <- testCompiler store provider testMarkdown compiler
     case result of
-        CompilerError es -> True H.@=? any ("invalid option" `isInfixOf`) es
+        CompilerError es -> True H.@=? any ("illegal option" `isInfixOf`) es
         _                -> H.assertFailure "Expecting CompilerError"
     cleanTestEnv
   where

--- a/tests/Hakyll/Core/UnixFilter/Tests.hs
+++ b/tests/Hakyll/Core/UnixFilter/Tests.hs
@@ -67,8 +67,10 @@ unixFilterError = do
     provider <- newTestProvider store
     result   <- testCompiler store provider testMarkdown compiler
     case result of
-        CompilerError es -> True H.@=? any ("illegal option" `isInfixOf`) es
+        CompilerError es -> True H.@=? any containsIncorrectOptionMessage es
         _                -> H.assertFailure "Expecting CompilerError"
     cleanTestEnv
   where
     compiler = getResourceString >>= withItemBody (unixFilter "head" ["-#"])
+    incorrectOptionMessages = ["invalid option", "illegal option"]
+    containsIncorrectOptionMessage output = any (`isInfixOf` output) incorrectOptionMessages


### PR DESCRIPTION
Corrected an assertion that just seems to be out-of-date.

Tests run locally:

```
All 133 tests passed (1.10s)

hakyll-4.12.4.0: Test suite hakyll-tests passed
Completed 2 action(s).
Updating Haddock index for local packages in
/Users/js033433/Software/haskell/hakyll/.stack-work/install/x86_64-osx/nightly-2018-08-29/8.4.3/doc/index.html
Updating Haddock index for local packages and dependencies in
/Users/js033433/Software/haskell/hakyll/.stack-work/install/x86_64-osx/nightly-2018-08-29/8.4.3/doc/all/index.html
Haddock index for snapshot packages already up to date at:
/Users/js033433/.stack/snapshots/x86_64-osx/nightly-2018-08-29/8.4.3/doc/index.html
```