### PR TITLE
Expose `getCategory` in Haskell.Web.Tags

### DIFF
--- a/lib/Hakyll/Web/Tags.hs
+++ b/lib/Hakyll/Web/Tags.hs
@@ -43,6 +43,7 @@
 module Hakyll.Web.Tags
     ( Tags (..)
     , getTags
+    , getCategory
     , buildTagsWith
     , buildTags
     , buildCategories


### PR DESCRIPTION
`getCategory` functions similarly to `getTags` and seems to be a pretty useful function to have.