### PR TITLE
fixed: auto complete `published` overwrites user's context

### DIFF
--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -177,4 +177,4 @@ renderAtom = renderAtomWithTemplates atomTemplate atomItemTemplate
 -- | Copies @$updated$@ from @$published$@ if it is not already set.
 makeItemContext :: String -> Context a -> Context a
 makeItemContext fmt context = mconcat
-    [dateField "published" fmt, context, dateField "updated" fmt]
+    [context, dateField "published" fmt, dateField "updated" fmt]


### PR DESCRIPTION
I like following, has written a context to complement from the file name `published`.

[www.ncaq.net/site.hs at d8b7eb3426eae36ee0ea5788f32306b9ffa6f9f2 · ncaq/www.ncaq.net](https://github.com/ncaq/www.ncaq.net/blob/d8b7eb3426eae36ee0ea5788f32306b9ffa6f9f2/site.hs#L120)

Looking at feed today, I noticed that time is not reflected in `published`.
This is because `getItemUTC` overwrites my `published`.
Adding a format to `getItemUTC` was not a solution because I live with JST.
Also, it is not realistic to write `published` in the yaml metadata of all files, and I think that you want to be delivered as JST as much as possible.
Since `updated` does not overwrite the context, I tried to rewrite so that `published` does not overwrite the context.
I have confirmed in the local environment that all things work well, is this the intended overwrite?
If not, I think it is natural to prioritize the user's context.