### PR TITLE
Update old dependencies for lts-13.x

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -166,7 +166,7 @@ Library
     blaze-html           >= 0.5      && < 0.10,
     blaze-markup         >= 0.5.1    && < 0.9,
     bytestring           >= 0.9      && < 0.11,
-    containers           >= 0.3      && < 0.6,
+    containers           >= 0.3      && < 0.7,
     cryptohash           >= 0.7      && < 0.12,
     data-default         >= 0.4      && < 0.8,
     deepseq              >= 1.3      && < 1.5,
@@ -227,7 +227,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc          >= 2.0.5    && < 2.5,
+      pandoc          >= 2.0.5    && < 2.6,
       pandoc-citeproc >= 0.14     && < 0.16
     Cpp-options:
       -DUSE_PANDOC
@@ -260,13 +260,13 @@ Test-suite hakyll-tests
   Build-Depends:
     hakyll,
     QuickCheck                 >= 2.8  && < 2.13,
-    tasty                      >= 0.11 && < 1.2,
+    tasty                      >= 0.11 && < 1.3,
     tasty-hunit                >= 0.9  && < 0.11,
     tasty-quickcheck           >= 0.8  && < 0.11,
     -- Copy pasted from hakyll dependencies:
     base                 >= 4.8      && < 5,
     bytestring           >= 0.9      && < 0.11,
-    containers           >= 0.3      && < 0.6,
+    containers           >= 0.3      && < 0.7,
     filepath             >= 1.0      && < 1.5,
     text                 >= 0.11     && < 1.3,
     unordered-containers >= 0.2      && < 0.3,
@@ -321,4 +321,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.0.5 && < 2.5
+    pandoc    >= 2.0.5 && < 2.6


### PR DESCRIPTION
Since I want to use Hakyll with lts-13.x, I updated the old dependencies.

Note: I used Travis CI for testing. Compared with CircleCI, I did not have to make comlicated settings. I might possibly send a pull request to update CI relationship. It was hard to use TravisCI in the past, but as GHC's perfomance got higher, it's okay now!

Squashed: https://github.com/Hexirp/hakyll/tree/lts-13.0