### PR TITLE
Bumps pandoc upper bound

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -228,7 +228,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc          >= 2.0.5    && < 2.7,
+      pandoc          >= 2.0.5    && < 2.8,
       pandoc-citeproc >= 0.14     && < 0.17
     Cpp-options:
       -DUSE_PANDOC
@@ -322,4 +322,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.0.5 && < 2.7
+    pandoc    >= 2.0.5 && < 2.8


### PR DESCRIPTION
This PR bumps the upper bound for `pandoc` to allow `hakyll` to build with `pandoc-2.7`, which was released today.

I've built `hakyll` locally and run tests with the `usePandoc` flag and everything seems to work.