### PR TITLE
Dependency error on `stack install hakyll`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,4 +12,4 @@ You can install this library using cabal:
 
 Or using stack:
 
-    stack install hakyll
+    stack install hakyll --resolver lts-12.26

--- a/web/index.markdown
+++ b/web/index.markdown
@@ -32,7 +32,7 @@ and TeX support, including syntax highlighting and other goodies.
 # Getting Started
 
 You can get the latest version from hackage using `cabal install hakyll`, or
-using [stack] by using `stack install hakyll`. Then, you can:
+using [stack] by using `stack install hakyll --resolver lts-12.26`. Then, you can:
 
 [stack]: http://www.haskellstack.org/
 

--- a/web/tutorials/01-installation.markdown
+++ b/web/tutorials/01-installation.markdown
@@ -11,7 +11,7 @@ Installation is provided via Hackage, and some packages are available for
 different distributions. For installation from source (i.e. via Hackage),
 [stack] is recommended:
 
-    $ stack install hakyll
+    $ stack install hakyll --resolver lts-12.26
 
 [stack]: http://www.haskellstack.org/
 
@@ -41,7 +41,7 @@ The file `site.hs` holds the configuration of your site, as an executable
 haskell program. We can compile and run it like this:
 
     $ cd my-site
-    $ stack init  # creates stack.yaml file based on my-site.cabal
+    $ stack init --resolver lts-12.26 # creates stack.yaml file based on my-site.cabal
     $ stack build
     $ stack exec site build
 


### PR DESCRIPTION
 - Set explicit resolver to latest Stackage LTS with hakyll included

Fix #684