### PR TITLE
Allow for multiple categories for getCategory with tests.

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -254,6 +254,7 @@ Test-suite hakyll-tests
     Hakyll.Web.CompressCss.Tests
     Hakyll.Web.Html.RelativizeUrls.Tests
     Hakyll.Web.Html.Tests
+    Hakyll.Web.Tags.Tests
     Hakyll.Web.Template.Context.Tests
     Hakyll.Web.Template.Tests
     TestSuite.Util

--- a/lib/Hakyll/Web/Tags.hs
+++ b/lib/Hakyll/Web/Tags.hs
@@ -72,7 +72,7 @@ import qualified Data.Map                        as M
 import           Data.Maybe                      (catMaybes, fromMaybe)
 import           Data.Ord                        (comparing)
 import qualified Data.Set                        as S
-import           System.FilePath                 (takeBaseName, takeDirectory)
+import           System.FilePath                 (takeDirectory, splitDirectories)
 import           Text.Blaze.Html                 (toHtml, toValue, (!))
 import           Text.Blaze.Html.Renderer.String (renderHtml)
 import qualified Text.Blaze.Html5                as H
@@ -115,7 +115,8 @@ getTags identifier = do
 --------------------------------------------------------------------------------
 -- | Obtain categories from a page.
 getCategory :: MonadMetadata m => Identifier -> m [String]
-getCategory = return . return . takeBaseName . takeDirectory . toFilePath
+getCategory = return . tail' . splitDirectories . takeDirectory . toFilePath
+  where tail' (_:xs) = xs; tail' _ = []
 
 
 --------------------------------------------------------------------------------

--- a/tests/Hakyll/Web/Tags/Tests.hs
+++ b/tests/Hakyll/Web/Tags/Tests.hs
@@ -1,0 +1,42 @@
+--------------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+module Hakyll.Web.Tags.Tests
+    ( tests
+    ) where
+
+--------------------------------------------------------------------------------
+import           Test.Tasty                  (TestTree, testGroup)
+import           Test.Tasty.HUnit            (Assertion, testCase, (@?=))
+
+--------------------------------------------------------------------------------
+import           Hakyll.Core.Identifier
+import           Hakyll.Core.Provider
+import           Hakyll.Core.Store           (Store)
+import           Hakyll.Web.Tags
+import           TestSuite.Util
+
+tests :: TestTree
+tests = testGroup "Hakyll.Web.Tags"
+    [ testCase "testGetCategory" testGetCategory
+    ]
+
+testGetCategory :: Assertion
+testGetCategory = do
+    store    <- newTestStore
+    provider <- newTestProvider store
+
+    noCategory1 <- testCategoryDone store provider "example.md"
+    noCategory1 @?= []
+
+    noCategory2 <- testCategoryDone store provider "posts/2010-08-26-birthday.md"
+    noCategory2 @?= []
+
+    severalCategories <- testCategoryDone store provider "posts/2019/05/10/tomorrow.md"
+    severalCategories @?= ["2019","05","10"]
+
+    cleanTestEnv
+
+--------------------------------------------------------------------------------
+testCategoryDone :: Store -> Provider -> Identifier -> IO [String]
+testCategoryDone store provider identifier =
+    testCompilerDone store provider identifier $ getCategory identifier

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -28,6 +28,7 @@ import qualified Hakyll.Web.Pandoc.FileType.Tests
 #endif
 import qualified Hakyll.Web.Template.Context.Tests
 import qualified Hakyll.Web.Template.Tests
+import qualified Hakyll.Web.Tags.Tests
 
 
 --------------------------------------------------------------------------------
@@ -49,6 +50,7 @@ main = defaultMain $ testGroup "Hakyll"
 #ifdef USE_PANDOC
     , Hakyll.Web.Pandoc.FileType.Tests.tests
 #endif
+    , Hakyll.Web.Tags.Tests.tests
     , Hakyll.Web.Template.Context.Tests.tests
     , Hakyll.Web.Template.Tests.tests
     ]


### PR DESCRIPTION
I didn't know what exactly `getCategory` was supposed to return so I wrote some tests to document the functionality and changed the implementation slightly to fit the tests.