### PR TITLE
Bump QuickCheck to 2.13

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -260,7 +260,7 @@ Test-suite hakyll-tests
 
   Build-Depends:
     hakyll,
-    QuickCheck                 >= 2.8  && < 2.13,
+    QuickCheck                 >= 2.8  && < 2.14,
     tasty                      >= 0.11 && < 1.3,
     tasty-hunit                >= 0.9  && < 0.11,
     tasty-quickcheck           >= 0.8  && < 0.11,


### PR DESCRIPTION
Tests appear to run fine (building on NixOS).