### PR TITLE
Made inner loops have access to outer loop values

### DIFF
--- a/lib/Hakyll/Web/Template/Context.hs
+++ b/lib/Hakyll/Web/Template/Context.hs
@@ -272,8 +272,8 @@ titleField = mapContext takeBaseName . pathField
 --
 -- As another alternative, if none of the above matches, and the file has a
 -- path which contains nested directories specifying a date, then that date
--- will be used. In other words, if the path is of the form 
--- @**//yyyy//mm//dd//**//main.extension@ . 
+-- will be used. In other words, if the path is of the form
+-- @**//yyyy//mm//dd//**//main.extension@ .
 -- As above, in case of multiple matches, the rightmost one is used.
 
 dateField :: String     -- ^ Key in which the rendered date should be placed

--- a/lib/Hakyll/Web/Template/Internal.hs
+++ b/lib/Hakyll/Web/Template/Internal.hs
@@ -18,6 +18,7 @@ module Hakyll.Web.Template.Internal
 
 
 --------------------------------------------------------------------------------
+import           Control.Applicative                  ((<|>))
 import           Control.Monad.Except                 (MonadError (..))
 import           Data.Binary                          (Binary)
 import           Data.List                            (intercalate)
@@ -134,8 +135,13 @@ applyTemplate' tes context x = go tes
             "got StringField for expr " ++ show e
         ListField c xs -> do
             sep <- maybe (return "") go s
-            bs  <- mapM (applyTemplate' b c) xs
+            bs  <- mapM (applyTemplate' b $ combineContexts context x c) xs
             return $ intercalate sep bs
+            where
+                combineContexts :: Context a -> Item a -> Context b -> Context b
+                combineContexts ca ia cb = Context $ \ k' args' ib' ->
+                    unContext cb k' args' ib'
+                    <|> unContext ca k' args' ia
 
     applyElem (Partial e) = do
         p             <- applyExpr e >>= getString e


### PR DESCRIPTION
If my outer loop in a template produces a value that I want to use in my inner loop, I get a `Missing field` error. 

This gives inner loops access to outer loop values and allows inner loops to override them.