### PR TITLE
use makeRelativeToProject in Hakyll.Web.Template.Tests

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -273,7 +273,8 @@ Test-suite hakyll-tests
     filepath             >= 1.0      && < 1.5,
     text                 >= 0.11     && < 1.3,
     unordered-containers >= 0.2      && < 0.3,
-    yaml                 >= 0.8.11   && < 0.12
+    yaml                 >= 0.8.11   && < 0.12,
+    file-embed           >= 0.0.10.1 && < 0.0.12
 
   If flag(previewServer)
     Cpp-options:

--- a/tests/Hakyll/Web/Template/Tests.hs
+++ b/tests/Hakyll/Web/Template/Tests.hs
@@ -23,6 +23,7 @@ import           Hakyll.Web.Template.Context
 import           Hakyll.Web.Template.Internal
 import           Hakyll.Web.Template.List
 import           TestSuite.Util
+import           Data.FileEmbed (makeRelativeToProject)
 
 
 --------------------------------------------------------------------------------
@@ -139,7 +140,7 @@ testApplyJoinTemplateList = do
 
 --------------------------------------------------------------------------------
 embeddedTemplate :: Template
-embeddedTemplate = $(embedTemplate "tests/data/embed.html")
+embeddedTemplate = $(makeRelativeToProject "tests/data/embed.html" >>= embedTemplate)
 
 --------------------------------------------------------------------------------
 testEmbeddedTemplate :: Assertion


### PR DESCRIPTION
This fixes a build error in [Nixpkgs](https://github.com/NixOS/nixpkgs/) where for some reason the path to `tests/data/template.html` couldn't be determined:

```
...
Preprocessing test suite 'hakyll-tests' for hakyll-4.13.0.0..
Building test suite 'hakyll-tests' for hakyll-4.13.0.0..
[ 1 of 19] Compiling TestSuite.Util   ( tests/TestSuite/Util.hs, dist/build/hakyll-tests/hakyll-tests-tmp/TestSuite/Util.o )
[ 2 of 19] Compiling Hakyll.Web.Template.Tests ( tests/Hakyll/Web/Template/Tests.hs, dist/build/hakyll-tests/hakyll-tests-tmp/Hakyll/Web/Template/Tests.o )

tests/Hakyll/Web/Template/Tests.hs:142:20: error:
    • Exception when trying to run compile-time code:
        tests/data/embed.html: openBinaryFile: does not exist (No such file or directory)
      Code: embedTemplate "tests/data/embed.html"
    • In the untyped splice: $(embedTemplate "tests/data/embed.html")
    |
142 | embeddedTemplate = $(embedTemplate "tests/data/embed.html")
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
```

I'm an Haskell newbie, so please excuse any obvious errors. I just found that `makeRelativeToProject` seems to be applied to other occurences of `embedTemplate` in the code so I figured it would make sense to apply it here as well.