### PR TITLE
add missing files to hakyll.cabal

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -59,6 +59,7 @@ Data-files:
 
 Extra-source-files:
   CHANGELOG.md
+  tests/data/embed.html
   tests/data/example.md
   tests/data/example.md.metadata
   tests/data/images/favicon.ico
@@ -69,6 +70,7 @@ Extra-source-files:
   tests/data/partial.html.out
   tests/data/posts/2010-08-26-birthday.md
   tests/data/posts/2018-09-26.md
+  tests/data/posts/2019/05/10/tomorrow.md
   tests/data/russian.md
   tests/data/strip.html
   tests/data/strip.html.out


### PR DESCRIPTION
This probably fixes a build error with the Hackage tarball of 4.13.0.0.

I noticed that the files

```
tests/data/embed.html
tests/data/posts/2019/05/10/tomorrow.md
```

are missing in the [hackage tarball](https://hackage.haskell.org/package/hakyll-4.13.0.0/hakyll-4.13.0.0.tar.gz), but are present in the Git repository. I guess adding them to `Extra-source-files` in `hakyll.cabal` fixes the build errors I experienced in [Nixpkgs](https://github.com/NixOS/nixpkgs/):

```
...
Preprocessing test suite 'hakyll-tests' for hakyll-4.13.0.0..
Building test suite 'hakyll-tests' for hakyll-4.13.0.0..
[ 1 of 19] Compiling TestSuite.Util   ( tests/TestSuite/Util.hs, dist/build/hakyll-tests/hakyll-tests-tmp/TestSuite/Util.o )
[ 2 of 19] Compiling Hakyll.Web.Template.Tests ( tests/Hakyll/Web/Template/Tests.hs, dist/build/hakyll-tests/hakyll-tests-tmp/Hakyll/Web/Template/Tests.o )

tests/Hakyll/Web/Template/Tests.hs:142:20: error:
    • Exception when trying to run compile-time code:
        tests/data/embed.html: openBinaryFile: does not exist (No such file or directory)
      Code: embedTemplate "tests/data/embed.html"
    • In the untyped splice: $(embedTemplate "tests/data/embed.html")
    |
142 | embeddedTemplate = $(embedTemplate "tests/data/embed.html")
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
```

```
...
  Hakyll.Web.Tags
    testGetCategory:       OK
  Hakyll.Web.Template.Context.Tests
    testDateField:         FAIL
      Exception: user error (TestSuite.Util.testCompilerDone: compiler posts/2019/05/10/tomorrow.md threw: Hakyll.Core.Compiler.getResourceWith: resource "posts/2019/05/10/tomorrow.md" not found)
  Hakyll.Web.Template.Tests
    case01:                FAIL
      Exception: user error (TestSuite.Util.testCompilerDone: compiler template.html threw: Hakyll.Core.Compiler.cached: Cache corrupt! Try running: hakyll-tests clean)
    case02:                FAIL
      Exception: user error (TestSuite.Util.testCompilerDone: compiler strip.html threw: Hakyll.Core.Compiler.cached: Cache corrupt! Try running: hakyll-tests clean)
    case03:                FAIL
      Exception: user error (TestSuite.Util.testCompilerDone: compiler just-meta.html threw: Hakyll.Core.Compiler.cached: Cache corrupt! Try running: hakyll-tests clean)
    applyJoinTemplateList: OK
    [ 1] parseTemplate:    OK
    [ 2] parseTemplate:    OK
    [ 3] parseTemplate:    OK
    [ 4] parseTemplate:    OK
    [ 5] parseTemplate:    OK
    [ 6] parseTemplate:    OK
    [ 7] parseTemplate:    OK
    [ 8] parseTemplate:    OK
    embeddedTemplate:      OK

4 out of 137 tests failed (0.47s)
Test suite hakyll-tests: FAIL
Test suite logged to: dist/test/hakyll-4.13.0.0-hakyll-tests.log
0 of 1 test suites (0 of 1 test cases) passed.
...
```