### PR TITLE
hakyll-init: fix spacing of command line usage

### DIFF
--- a/src/Init.hs
+++ b/src/Init.hs
@@ -46,7 +46,7 @@ main = do
         ["-f", dstDir] ->
             createFiles True srcDir files dstDir
         _ -> do
-            putStrLn $ "Usage: " ++ progName ++ "[-f] <directory>"
+            putStrLn $ "Usage: " ++ progName ++ " [-f] <directory>"
             exitFailure
 
     where


### PR DESCRIPTION
used to be:

```
$ hakyll-init -h
Usage: hakyll-init[-f] <directory>
```