### PR TITLE
update stack.yaml to lts-14.12

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.29
+resolver: lts-14.12
 save-hackage-creds: false
 
 flags:
@@ -21,13 +21,3 @@ build:
   haddock: true
   haddock-hyperlink-source: true
   haddock-deps: false
-
-extra-deps:
-- 'cmark-gfm-0.2.0'
-- 'hslua-module-system-0.2.1'
-- 'ipynb-0.1'
-- 'lrucache-1.2.0.1'
-- 'pandoc-2.7.3'
-- 'pandoc-citeproc-0.16.2'
-- 'skylighting-0.8.2'
-- 'skylighting-core-0.8.2'


### PR DESCRIPTION
When building locally I saw that hakyll builds fine against current lts without the extra-deps. No idea if you want this.
