### PR TITLE
Flush log before starting web server

### DIFF
--- a/lib/Hakyll/Preview/Server.hs
+++ b/lib/Hakyll/Preview/Server.hs
@@ -24,6 +24,7 @@ staticServer :: Logger               -- ^ Logger
              -> IO ()                -- ^ Blocks forever
 staticServer logger directory host port = do
     Logger.header logger $ "Listening on http://" ++ host ++ ":" ++ show port
+    Logger.flush logger -- ensure this line is logged before Warp errors
     Warp.runSettings warpSettings $
         Static.staticApp (Static.defaultFileServerSettings directory)
   where


### PR DESCRIPTION
This fixes out of order console messaging in the case of errors
binding to the configured address, though the message order is
still a bit weird.

Before:

```
$ stack exec site watch
Initialising...
  Creating store...
site: Network.Socket.bind: resource busy (Address already in use)
  Creating provider...
Listening on http://127.0.0.1:8000
```

After:

```
$ stack exec site watch
Listening on http://127.0.0.1:8000
Initialising...
  Creating store...
  Creating provider...
site: Network.Socket.bind: resource busy (Address already in use)
```