### PR TITLE
Clean stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.29
+resolver: lts-13.30
 save-hackage-creds: false
 
 flags:
@@ -23,11 +23,4 @@ build:
   haddock-deps: false
 
 extra-deps:
-- 'cmark-gfm-0.2.0'
-- 'hslua-module-system-0.2.1'
-- 'ipynb-0.1'
 - 'lrucache-1.2.0.1'
-- 'pandoc-2.7.3'
-- 'pandoc-citeproc-0.16.2'
-- 'skylighting-0.8.2'
-- 'skylighting-core-0.8.2'


### PR DESCRIPTION
I bump stack resolver version to lts-13.30. And I clean the extra-deps field
because those packages are already included in lts-13.30.