### PR TITLE
Remove constant field title for index.html in the example site

### DIFF
--- a/data/example/site.hs
+++ b/data/example/site.hs
@@ -49,7 +49,6 @@ main = hakyll $ do
             posts <- recentFirst =<< loadAll "posts/*"
             let indexCtx =
                     listField "posts" postCtx (return posts) `mappend`
-                    constField "title" "Home"                `mappend`
                     defaultContext
 
             getResourceBody


### PR DESCRIPTION
In the default site generated by Hakyll, `index.html` has specified the filed `title` in its front matter, but it will always been overridden by `constField "title" "Home"` in `site.hs`.

It is a very minor issue, but it may cause confusion to newcomers.