### PR TITLE
Expose CLI arg parser internals

### DIFF
--- a/lib/Hakyll/Main.hs
+++ b/lib/Hakyll/Main.hs
@@ -3,7 +3,13 @@
 {-# LANGUAGE CPP #-}
 
 module Hakyll.Main
-    ( hakyll
+    ( optionParser
+    , commandParser
+    , defaultParser
+    , defaultParserPure
+    , defaultParserPrefs
+    , defaultParserInfo
+    , hakyll
     , hakyllWith
     , hakyllWithArgs
     , hakyllWithExitCode
@@ -72,11 +78,24 @@ hakyllWithExitCodeAndArgs conf args rules = do
 --------------------------------------------------------------------------------
 defaultParser :: Config.Configuration -> IO Options
 defaultParser conf =
-    OA.customExecParser (OA.prefs OA.showHelpOnError)
-        (OA.info (OA.helper <*> optionParser conf)
-        (OA.fullDesc <> OA.progDesc
-        (progName ++ " - Static site compiler created with Hakyll")))
+    OA.customExecParser defaultParserPrefs (defaultParserInfo conf)
 
+
+--------------------------------------------------------------------------------
+defaultParserPure :: Config.Configuration -> [String] -> OA.ParserResult Options
+defaultParserPure conf =
+  OA.execParserPure defaultParserPrefs (defaultParserInfo conf)
+
+
+--------------------------------------------------------------------------------
+defaultParserPrefs :: OA.ParserPrefs
+defaultParserPrefs = OA.prefs OA.showHelpOnError
+
+--------------------------------------------------------------------------------
+defaultParserInfo :: Config.Configuration -> OA.ParserInfo Options
+defaultParserInfo conf =
+  OA.info (OA.helper <*> optionParser conf) (OA.fullDesc <> OA.progDesc (
+                                                progName ++ " - Static site compiler created with Hakyll"))
 
 --------------------------------------------------------------------------------
 invokeCommands :: Command -> Config.Configuration ->


### PR DESCRIPTION
Resolves #751

I have two example commits on my own site that use this:
- [This first example simply uses `defaultParserPure`](https://github.com/jhmcstanton/jhmcstanton.github.io/commit/2220206fdd88a915f67c05929acde376ab23e97b)
- [This example makes use of a custom `SiteOptions` type](https://github.com/jhmcstanton/jhmcstanton.github.io/commit/2ebe9deda6a1438096b9a008d9fb7438c280cf67#diff-d969b25c2913c74b1bb1fb5b91807fffR19)

