### PR TITLE
Add UPenn PL Club to list of examples

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -221,3 +221,5 @@ directly with the default Hakyll site.
   [source](https://github.com/CharlesStain/alfredodinapoli.com)
 - <http://michaelxavier.net>,
   [source](https://github.com/michaelxavier/michaelxavier.net)
+- <https://www.cis.upenn.edu/~plclub/>,
+  [source](https://github.com/plclub/plclub-web)


### PR DESCRIPTION
The UPenn PL research group launched a new Hakyll site this year