### PR TITLE
Fix for filepaths matching on Windows.

### DIFF
--- a/lib/Hakyll/Core/Identifier.hs
+++ b/lib/Hakyll/Core/Identifier.hs
@@ -22,7 +22,7 @@ module Hakyll.Core.Identifier
 import           Control.DeepSeq     (NFData (..))
 import           Data.List           (intercalate)
 import           System.FilePath     (dropTrailingPathSeparator, splitPath,
-                                      pathSeparator)
+                                      pathSeparator, normalise)
 
 
 --------------------------------------------------------------------------------
@@ -64,18 +64,13 @@ instance Show Identifier where
 --------------------------------------------------------------------------------
 -- | Parse an identifier from a string
 fromFilePath :: FilePath -> Identifier
-fromFilePath = Identifier Nothing .
-    intercalate "/" . filter (not . null) . split'
-  where
-    split' = map dropTrailingPathSeparator . splitPath
+fromFilePath = Identifier Nothing . normalise
 
 
 --------------------------------------------------------------------------------
 -- | Convert an identifier to a relative 'FilePath'
 toFilePath :: Identifier -> FilePath
-toFilePath = intercalate [pathSeparator] . split' . identifierPath
-  where
-    split' = map dropTrailingPathSeparator . splitPath
+toFilePath = normalise . identifierPath
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Core/Identifier/Pattern.hs
+++ b/lib/Hakyll/Core/Identifier/Pattern.hs
@@ -183,7 +183,7 @@ matches (Complement p) i = not $ matches p i
 matches (And x y)      i = matches x i && matches y i
 matches (Glob p)       i = isJust $ capture (Glob p) i
 matches (List l)       i = i `S.member` l
-matches (Regex r)      i = toFilePath i =~ r
+matches (Regex r)      i = (normaliseRegex $ toFilePath i) =~ r
 matches (Version v)    i = identifierVersion i == v
 
 
@@ -205,7 +205,7 @@ splits = inits &&& tails >>> uncurry zip >>> reverse
 capture :: Pattern -> Identifier -> Maybe [String]
 capture (Glob p) i = capture' p (toFilePath i)
 capture (Regex pat) i = Just groups
-  where (_, _, _, groups) = ((toFilePath i) =~ pat) :: (String, String, String, [String])
+  where (_, _, _, groups) = ((normaliseRegex $ toFilePath i) =~ pat) :: (String, String, String, [String])
 capture _        _ = Nothing
 
 
@@ -263,4 +263,9 @@ fromCaptures' (m : ms) [] = case m of
 fromCaptures' (m : ms) ids@(i : is) = case m of
     Literal l -> l `mappend` fromCaptures' ms ids
     _         -> i `mappend` fromCaptures' ms is
-    
+
+
+--------------------------------------------------------------------------------
+-- | Normalise filepaths to have '/' as a path separator for Regex matching
+normaliseRegex :: FilePath -> FilePath
+normaliseRegex = concatMap (\c -> if c == '\\' then ['/'] else [c])

--- a/tests/Hakyll/Core/Identifier/Tests.hs
+++ b/tests/Hakyll/Core/Identifier/Tests.hs
@@ -13,6 +13,7 @@ import           Test.Tasty.HUnit               ((@=?))
 --------------------------------------------------------------------------------
 import           Hakyll.Core.Identifier
 import           Hakyll.Core.Identifier.Pattern
+import           System.FilePath                ((</>))
 import           TestSuite.Util
 
 
@@ -27,22 +28,22 @@ tests = testGroup "Hakyll.Core.Identifier.Tests" $ concat
 --------------------------------------------------------------------------------
 captureTests :: [TestTree]
 captureTests = fromAssertions "capture"
-    [ Just ["bar"]              @=? capture "foo/**" "foo/bar"
-    , Just ["foo/bar"]          @=? capture "**" "foo/bar"
-    , Nothing                   @=? capture "*" "foo/bar"
-    , Just []                   @=? capture "foo" "foo"
-    , Just ["foo"]              @=? capture "*/bar" "foo/bar"
-    , Just ["foo/bar"]          @=? capture "**/qux" "foo/bar/qux"
-    , Just ["foo/bar", "qux"]   @=? capture "**/*" "foo/bar/qux"
-    , Just ["foo", "bar/qux"]   @=? capture "*/**" "foo/bar/qux"
-    , Just ["foo"]              @=? capture "*.html" "foo.html"
-    , Nothing                   @=? capture "*.html" "foo/bar.html"
-    , Just ["foo/bar"]          @=? capture "**.html" "foo/bar.html"
-    , Just ["foo/bar", "wut"]   @=? capture "**/qux/*" "foo/bar/qux/wut"
-    , Just ["lol", "fun/large"] @=? capture "*cat/**.jpg" "lolcat/fun/large.jpg"
-    , Just []                   @=? capture "\\*.jpg" "*.jpg"
-    , Nothing                   @=? capture "\\*.jpg" "foo.jpg"
-    , Just ["xyz","42"]              @=? capture (fromRegex "cat-([a-z]+)/foo([0-9]+).jpg") "cat-xyz/foo42.jpg"
+    [ Just ["bar"]                    @=? capture "foo/**" "foo/bar"
+    , Just ["foo" </> "bar"]          @=? capture "**" "foo/bar"
+    , Nothing                         @=? capture "*" "foo/bar"
+    , Just []                         @=? capture "foo" "foo"
+    , Just ["foo"]                    @=? capture "*/bar" "foo/bar"
+    , Just ["foo" </> "bar"]          @=? capture "**/qux" "foo/bar/qux"
+    , Just ["foo" </> "bar", "qux"]   @=? capture "**/*" "foo/bar/qux"
+    , Just ["foo", "bar" </> "qux"]   @=? capture "*/**" "foo/bar/qux"
+    , Just ["foo"]                    @=? capture "*.html" "foo.html"
+    , Nothing                         @=? capture "*.html" "foo/bar.html"
+    , Just ["foo" </> "bar"]          @=? capture "**.html" "foo/bar.html"
+    , Just ["foo" </> "bar", "wut"]   @=? capture "**/qux/*" "foo/bar/qux/wut"
+    , Just ["lol", "fun" </> "large"] @=? capture "*cat/**.jpg" "lolcat/fun/large.jpg"
+    , Just []                         @=? capture "\\*.jpg" "*.jpg"
+    , Nothing                         @=? capture "\\*.jpg" "foo.jpg"
+    , Just ["xyz","42"]               @=? capture (fromRegex "cat-([a-z]+)/foo([0-9]+).jpg") "cat-xyz/foo42.jpg"
     ]
 
 

--- a/tests/Hakyll/Core/Identifier/Tests.hs
+++ b/tests/Hakyll/Core/Identifier/Tests.hs
@@ -41,7 +41,6 @@ captureTests = fromAssertions "capture"
     , Just ["foo" </> "bar"]          @=? capture "**.html" "foo/bar.html"
     , Just ["foo" </> "bar", "wut"]   @=? capture "**/qux/*" "foo/bar/qux/wut"
     , Just ["lol", "fun" </> "large"] @=? capture "*cat/**.jpg" "lolcat/fun/large.jpg"
-    , Just []                         @=? capture "\\*.jpg" "*.jpg"
     , Nothing                         @=? capture "\\*.jpg" "foo.jpg"
     , Just ["xyz","42"]               @=? capture (fromRegex "cat-([a-z]+)/foo([0-9]+).jpg") "cat-xyz/foo42.jpg"
     ]


### PR DESCRIPTION
This pull request aims to fix issue #766 , where `Rules` were not firing properly on Windows.

Files on Windows were not being captured properly by `Hakyll.Core.Identifier.Pattern.capture`. To fix this, all paths becoming `Identifier`s are being normalized to have the Windows path separator `\\`. This requires modification of `Hakyll.Core.Identifier.Pattern.fromGlob` function. Also, regex matching on Windows paths needed to change a little.

After this fix, the test site produced by `hakyll-init` compiles properly.

I also want to point out that trying to glob `\\*.jpg` is invalid on Windows, so I removed this test case. This also simplifies the parsing of glob patterns.