### PR TITLE
Remove unnecessary conditional compilation for parseTimeM

### DIFF
--- a/lib/Hakyll/Web/Template/Context.hs
+++ b/lib/Hakyll/Web/Template/Context.hs
@@ -60,8 +60,7 @@ import           Data.List                     (intercalate, tails)
 import           Data.Semigroup                (Semigroup (..))
 #endif
 import           Data.Time.Clock               (UTCTime (..))
-import           Data.Time.Format              (formatTime)
-import qualified Data.Time.Format              as TF
+import           Data.Time.Format              (formatTime, parseTimeM)
 import           Data.Time.Locale.Compat       (TimeLocale, defaultTimeLocale)
 import           Hakyll.Core.Compiler
 import           Hakyll.Core.Compiler.Internal
@@ -463,10 +462,3 @@ teaserFieldWithSeparator separator key snapshot = field key $ \item -> do
 missingField :: Context a
 missingField = Context $ \k _ _ -> noResult $
     "Missing field '" ++ k ++ "' in context"
-
-parseTimeM :: Bool -> TimeLocale -> String -> String -> Maybe UTCTime
-#if MIN_VERSION_time(1,5,0)
-parseTimeM = TF.parseTimeM
-#else
-parseTimeM _ = TF.parseTime
-#endif


### PR DESCRIPTION
The version of package `time` is required to be `>= 1.8` 

https://github.com/jaspervdj/hakyll/blob/8afbb62ed5e969d78d8664df205646504f52f278/hakyll.cabal#L193

so the conditional compilation below 

https://github.com/jaspervdj/hakyll/blob/8afbb62ed5e969d78d8664df205646504f52f278/lib/Hakyll/Web/Template/Context.hs#L467-L472

is not needed anymore.