### PR TITLE
Fix GitHub workflow scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,58 @@
-name: 'CI'
-on: ['push']
+name: CI
+on: [push]
+
 jobs:
-  build:
+  Ubuntu:
+    runs-on: ubuntu-latest
+    
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-      
-    name: ${{ matrix.os }}
-    runs-on: $${{ matrix.os }}
-    
+        ghc-ver: [8.8.3]
+
+    env:
+      ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc --fast"
+
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v2'
+    - uses: actions/setup-haskell@v1.1
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
     - uses: 'mstksg/setup-stack@v1'
     - uses: 'actions/cache@v1'
       with:
         path: '~/.stack'
-        key: "${{ runner.os }}-v3-stack-${{ hashFiles('stack.yaml.lock') }}"
-        restore-keys: '${{ runner.os }}-v3-stack'
-    - run: 'stack build --test'
+        key: "v3-stack-${{ hashFiles('stack-${{ matrix-ghc-ver }}.yaml') }}"
+        restore-keys: 'v3-stack'
+    - name: Install dependencies
+      run: |
+        stack build ${ARGS} --test --only-dependencies
+    - name: Build Hakyll
+      run: |
+        stack build ${ARGS} --test
+
+  Windows:
+    runs-on: windows-latest
+    
+    strategy:
+      matrix:
+        ghc-ver: [8.8.3]
+
+    env:
+      ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc --fast"
+
+    steps:
+    - uses: 'actions/checkout@v2'
+    - uses: actions/setup-haskell@v1.1
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
+    - uses: 'actions/cache@v1'
+      with:
+        path: '~/.stack'
+        key: "v3-stack-${{ hashFiles('stack-${{ matrix-ghc-ver }}.yaml') }}"
+        restore-keys: 'v3-stack'
+    - name: Install dependencies
+      run: |
+        stack build ${ARGS} --test --only-dependencies
+    - name: Build Hakyll
+      run: |
+        stack build ${ARGS} --test

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -1,0 +1,27 @@
+resolver: lts-16.0
+save-hackage-creds: false
+
+flags:
+  hakyll:
+    previewServer: true
+    watchServer:   true
+    checkExternal: true
+    usePandoc:     true
+    buildWebsite:  true
+
+packages:
+  - '.'
+
+nix:
+  enable: false
+  packages:
+    - zlib
+
+build:
+  haddock: true
+  haddock-hyperlink-source: true
+  haddock-deps: false
+
+extra-deps:
+- 'lrucache-1.2.0.1'
+- 'warp-3.3.9'


### PR DESCRIPTION
It doesn't seem possible to use `strategy.matrix` to specify what OS to run. So, instead, there are two separate jobs for Ubuntu and for Windows. Moreover, the GitHub Action `mstksg/setup-stack` does not support Windows despite what it claims (see [here](https://github.com/mstksg/setup-stack/issues/5)), so it doesn't make sense to use the same steps on different OS environments.

For some compatibility issue, I put an additional `stack-8.8.3.yaml` so that in the future it is easier to run workflows for different GHC versions if you'd like.

Due to a GHC bug, it fails to install Hakyll on Windows for some mysterious reason while building SHA: 

> SHA                              > Access violation in generated code when writing 0x0