### PR TITLE
Support recent template-haskell and pandoc releases.

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -232,7 +232,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc          >= 2.0.5    && < 2.10,
+      pandoc          >= 2.0.5    && < 2.11,
       pandoc-citeproc >= 0.14     && < 0.18
     Cpp-options:
       -DUSE_PANDOC
@@ -327,4 +327,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.0.5 && < 2.10
+    pandoc    >= 2.0.5 && < 2.11

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -188,7 +188,7 @@ Library
     resourcet            >= 1.1      && < 1.3,
     scientific           >= 0.3.4    && < 0.4,
     tagsoup              >= 0.13.1   && < 0.15,
-    template-haskell     >= 2.14     && < 2.16,
+    template-haskell     >= 2.14     && < 2.17,
     text                 >= 0.11     && < 1.3,
     time                 >= 1.8      && < 1.10,
     time-locale-compat   >= 0.1      && < 0.2,

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -232,7 +232,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc          >= 2.0.5    && < 2.11,
+      pandoc          >= 2.10     && < 2.11,
       pandoc-citeproc >= 0.14     && < 0.18
     Cpp-options:
       -DUSE_PANDOC
@@ -327,4 +327,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.0.5 && < 2.11
+    pandoc    >= 2.10  && < 2.11

--- a/lib/Hakyll/Web/Pandoc/Binary.hs
+++ b/lib/Hakyll/Web/Pandoc/Binary.hs
@@ -14,6 +14,10 @@ import           Text.Pandoc
 
 instance Binary Alignment
 instance Binary Block
+instance Binary Caption
+instance Binary Cell
+instance Binary ColSpan
+instance Binary ColWidth
 instance Binary CSL.Reference
 instance Binary Citation
 instance Binary CitationMode
@@ -29,5 +33,11 @@ instance Binary REF.Literal
 instance Binary REF.RefDate
 instance Binary REF.RefType
 instance Binary REF.Season
+instance Binary Row
+instance Binary RowHeadColumns
+instance Binary RowSpan
 instance Binary STY.Agent
 instance Binary STY.Formatted
+instance Binary TableBody
+instance Binary TableFoot
+instance Binary TableHead


### PR DESCRIPTION
- Bumped package bounds in hakyll.cabal
- Added Binary instances for datatypes recently added for pandoc tables ([relevant commit](https://github.com/jgm/pandoc-types/commit/f76c1b7db0931c4fe357827033e75efe5ab4f6bf#diff-8c56b05df299ade82ea6265ee0b71bd0))


Built/installed ok with ghc-8.10.1 & cabal-3.2.0.0.