### PR TITLE
Update a reference to Debian stable

### DIFF
--- a/web/tutorials/01-installation.markdown
+++ b/web/tutorials/01-installation.markdown
@@ -21,7 +21,7 @@ Hakyll.
 
 3.  There are also some Linux distro packages:
 
-    - [Debian unstable](http://packages.debian.org/source/sid/haskell-hakyll)
+    - [Debian](https://packages.debian.org/source/stable/haskell-hakyll)
     - [Fedora](https://apps.fedoraproject.org/packages/ghc-hakyll)
     - [Nix]: `$ nix-env -iA nixos.haskellPackages.hakyll`
 


### PR DESCRIPTION
Hakyll has been available in the Debian stable release for a while now so this patch makes it clear one does not need to use Debian unstable to install a package for Hakyll.