### PR TITLE
Bump pandoc version

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -327,4 +327,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.10  && < 2.11
+    pandoc    >= 2.10  && < 2.12

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -232,7 +232,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc          >= 2.10     && < 2.11,
+      pandoc          >= 2.10     && < 2.12,
       pandoc-citeproc >= 0.14     && < 0.18
     Cpp-options:
       -DUSE_PANDOC


### PR DESCRIPTION
Hej
I tried building hakyll using Nix where currently it is marked as broken because pandoc 2.10 can not be satisfied by nix since 2.11 is out.
I patched the cabal file manually (extending the pandoc version constraints to include 2.11) and my blog still compiles.
This PR just upstreams that change.
Probably there might be incompatibilities I just missed, any hints how to assess this and make hakyll compatible with the latest pandoc?
