### PR TITLE
Bump Stackage LTS to 16.21

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.9
+resolver: lts-16.21
 save-hackage-creds: false
 
 flags:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -55,7 +55,7 @@ packages:
     hackage: pandoc-types-1.21
 snapshots:
 - completed:
-    size: 532380
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/9.yaml
-    sha256: 14a7cec114424e4286adde73364438927a553ed248cc50f069a30a67e3ee1e69
-  original: lts-16.9
+    size: 532413
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/21.yaml
+    sha256: 7b5cac89352fa4a88606dc6cb250aee9291f21e2e988d464065f5aa51f5de33d
+  original: lts-16.21


### PR DESCRIPTION
This also bumps GHC versions from 8.8.3 to 8.8.4.