### PR TITLE
Update actions/setup-haskell to 1.1.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
   cabal:
     name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
+    env:
+      # Workaround for actions/setup-haskell@1.1.3 on Windows: https://github.com/actions/runner/pull/779
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -32,7 +35,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.1
+    - uses: actions/setup-haskell@v1.1.3
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -70,7 +73,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1
+    - uses: actions/setup-haskell@v1.1.3
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
This update is necessary since actions/setup-haskell@1.1.1 that we were using required `add-path`, which [was removed yesterday](https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16) (after two weeks of being deprecated due to some CVE).