### PR TITLE
Update actions/setup-haskell to 1.1.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,6 @@ jobs:
   cabal:
     name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
-    env:
-      # Workaround for actions/setup-haskell@1.1.3 on Windows: https://github.com/actions/runner/pull/779
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -35,7 +32,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: actions/setup-haskell@v1.1.4
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -73,7 +70,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: actions/setup-haskell@v1.1.4
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
This removes the need for a workaround on Windows.