### PR TITLE
Fix golden test failing with pandoc >= 2.11.3

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -299,6 +299,8 @@ Test-suite hakyll-tests
     Other-modules:
       Hakyll.Web.Pandoc.Biblio.Tests
       Hakyll.Web.Pandoc.FileType.Tests
+    Build-Depends:
+      pandoc >= 2.11 && < 2.12
     Cpp-options:
       -DUSE_PANDOC
 

--- a/tests/Hakyll/Web/Pandoc/Biblio/Tests.hs
+++ b/tests/Hakyll/Web/Pandoc/Biblio/Tests.hs
@@ -1,5 +1,6 @@
 --------------------------------------------------------------------------------
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP               #-}
 module Hakyll.Web.Pandoc.Biblio.Tests
     ( tests
     ) where
@@ -36,7 +37,11 @@ goldenTest01 :: TestTree
 goldenTest01 =
     goldenVsString
         "biblio01"
+#if MIN_VERSION_pandoc(2,11,3)
         (goldenTestsDataDir </> "biblio01.golden")
+#else
+        (goldenTestsDataDir </> "biblio01-pre-pandoc-2.11.3.golden")
+#endif
         (do
             -- Code lifted from https://github.com/jaspervdj/hakyll-citeproc-example.
             logger <- Logger.new Logger.Error

--- a/tests/data/biblio/biblio01-pre-pandoc-2.11.3.golden
+++ b/tests/data/biblio/biblio01-pre-pandoc-2.11.3.golden
@@ -9,7 +9,7 @@
         <p>I would like to cite one of my favourite papers <span class="citation" data-cites="meijer1991functional">(Meijer, Fokkinga, and Paterson 1991)</span> here.</p>
 <div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
 <div id="ref-meijer1991functional" class="csl-entry" role="doc-biblioentry">
-<p>Meijer, Erik, Maarten Fokkinga, and Ross Paterson. 1991. <span>“Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire.”</span> In <em>Conference on Functional Programming Languages and Computer Architecture</em>, 124–44. Springer.</p>
+Meijer, Erik, Maarten Fokkinga, and Ross Paterson. 1991. <span>“Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire.”</span> In <em>Conference on Functional Programming Languages and Computer Architecture</em>, 124–44. Springer.
 </div>
 </div>
     </body>


### PR DESCRIPTION
The new version started wrapping Biblio references into \<p> tags, so we now keep two different golden files for different Pandoc versions.

I had to add Pandoc to dependencies of the test suite, otherwise GHC won't define `MIN_VERSION_pandoc` macro.