### PR TITLE
Added a modified `pandocCompilerWithTransformM` that takes in an item as an extra argument

### DIFF
--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -8,6 +8,8 @@ module Hakyll.Web.Pandoc
     , writePandocWith
     , renderPandoc
     , renderPandocWith
+    , renderPandocWithTransform
+    , renderPandocWithTransformM
 
       -- * Derived compilers
     , pandocCompiler
@@ -104,6 +106,32 @@ renderPandocWith ropt wopt item =
 
 
 --------------------------------------------------------------------------------
+-- | An extension of `renderPandocWith`, which allows you to specify a custom
+-- Pandoc transformation on the input `Item`.
+-- Useful if you want to do your own transformations before running 
+-- custom Pandoc transformations, e.g. using a `funcField` to transform raw content.
+renderPandocWithTransform :: ReaderOptions -> WriterOptions
+                    -> (Pandoc -> Pandoc)
+                    -> Item String
+                    -> Compiler (Item String)
+renderPandocWithTransform ropt wopt f = 
+    renderPandocWithTransformM ropt wopt (return . f) 
+
+
+--------------------------------------------------------------------------------
+-- | Similar to `renderPandocWithTransform`, but the Pandoc transformation is
+-- monadic. This is useful when you want the pandoc
+-- transformation to use the `Compiler` information such as routes,
+-- metadata, etc. along with your own transformations beforehand.
+renderPandocWithTransformM :: ReaderOptions -> WriterOptions
+                    -> (Pandoc -> Compiler Pandoc)
+                    -> Item String
+                    -> Compiler (Item String)
+renderPandocWithTransformM ropt wopt f i = 
+    writePandocWith wopt <$> (traverse f =<< readPandocWith ropt i) 
+
+
+--------------------------------------------------------------------------------
 -- | Read a page render using pandoc
 pandocCompiler :: Compiler (Item String)
 pandocCompiler =
@@ -138,19 +166,7 @@ pandocCompilerWithTransformM :: ReaderOptions -> WriterOptions
                     -> (Pandoc -> Compiler Pandoc)
                     -> Compiler (Item String)
 pandocCompilerWithTransformM ropt wopt f = 
-    getResourceBody >>= applyPandocWith ropt wopt f
-
-
---------------------------------------------------------------------------------
--- | Similar to pandocCompilerWithTransformM, but takes an `Item String` as an
--- additional argument. Useful if you want to do transformations before doing a
--- custom Pandoc transformation, e.g. using custom templating functions.
-applyPandocWith :: ReaderOptions -> WriterOptions
-                    -> (Pandoc -> Compiler Pandoc)
-                    -> Item String
-                    -> Compiler (Item String)
-applyPandocWith ropt wopt f i = 
-    writePandocWith wopt <$> (traverse f =<< readPandocWith ropt i) 
+    getResourceBody >>= renderPandocWithTransformM ropt wopt f
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -149,8 +149,8 @@ applyPandocWith :: ReaderOptions -> WriterOptions
                     -> (Pandoc -> Compiler Pandoc)
                     -> Item String
                     -> Compiler (Item String)
-applyPandocWith ropt wopt f = 
-    readPandocWith ropt >=> traverse f >=> pure . writePandocWith wopt
+applyPandocWith ropt wopt f i = 
+    writePandocWith wopt <$> (traverse f =<< readPandocWith ropt i) 
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -137,9 +137,20 @@ pandocCompilerWithTransform ropt wopt f =
 pandocCompilerWithTransformM :: ReaderOptions -> WriterOptions
                     -> (Pandoc -> Compiler Pandoc)
                     -> Compiler (Item String)
-pandocCompilerWithTransformM ropt wopt f =
-    writePandocWith wopt <$>
-        (traverse f =<< readPandocWith ropt =<< getResourceBody)
+pandocCompilerWithTransformM ropt wopt f = 
+    getResourceBody >>= applyPandocWith ropt wopt f
+
+
+--------------------------------------------------------------------------------
+-- | Similar to pandocCompilerWithTransformM, but takes an `Item String` as an
+-- additional argument. Useful if you want to do transformations before passing
+-- data into Pandoc, e.g. using custom templating functions.
+applyPandocWith :: ReaderOptions -> WriterOptions
+                    -> (Pandoc -> Compiler Pandoc)
+                    -> Item String
+                    -> Compiler (Item String)
+applyPandocWith ropt wopt f = 
+    readPandocWith ropt >=> traverse f >=> pure . writePandocWith wopt
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -143,8 +143,8 @@ pandocCompilerWithTransformM ropt wopt f =
 
 --------------------------------------------------------------------------------
 -- | Similar to pandocCompilerWithTransformM, but takes an `Item String` as an
--- additional argument. Useful if you want to do transformations before passing
--- data into Pandoc, e.g. using custom templating functions.
+-- additional argument. Useful if you want to do transformations before doing a
+-- custom Pandoc transformation, e.g. using custom templating functions.
 applyPandocWith :: ReaderOptions -> WriterOptions
                     -> (Pandoc -> Compiler Pandoc)
                     -> Item String


### PR DESCRIPTION
I don't know if this is actually helpful, but I got stuck trying to apply transformations to source files before passing them into `pandocCompilerWithTransformM`. 

For context - the current implementation of `pandocCompilerWithTransformM` calls `getResourceBody` in its implementation, but it would be nice to have it more open so that pre-pandoc transformations can be done, along with custom traversals of the pandoc AST. There's already `renderPandocWith` which takes in an item, but no variation that allows for a `Pandoc -> Compiler Pandoc` function to be passed in as well. 

I'm using this on my personal site already and it's pretty useful - I have some pages where I'd like to apply `functionField`s before passing them off to pandoc (e.g. macros for embedding links to SVGs). 

The function name `applyPandocWith` is tentative, I don't know if it should derive from `renderPandocWith` or `pandocCompilerWithTransformM`. Maybe `pandocCompilerWithTransformFromItemM`? That might be too concise ;)

Please let me know if you need any more changes. Compiles and builds the test site successfully.