### PR TITLE
Allow pandoc 2.12

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -237,7 +237,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.12
+      pandoc >= 2.11 && < 2.13
     Cpp-options:
       -DUSE_PANDOC
 
@@ -333,4 +333,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.11  && < 2.12
+    pandoc    >= 2.11  && < 2.13


### PR DESCRIPTION
This passed on my machine:

    cabal test all -j --enable-tests --constrain 'pandoc == 2.12'