### PR TITLE
Allow pandoc 2.13

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -237,7 +237,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.13
+      pandoc >= 2.11 && < 2.14
     Cpp-options:
       -DUSE_PANDOC
 
@@ -333,4 +333,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.11  && < 2.13
+    pandoc    >= 2.11  && < 2.14


### PR DESCRIPTION
It should work, I'm guessing, not much has changed, so let's see if CI tests pass?

Do drafts go into CI pipeline? I guess we'll see...

EDIT: build seems to be successful, at least on some GHC versions with the newer pandoc, so marking this as non-draft.