### PR TITLE
Fix typo in configuration code

### DIFF
--- a/web/tutorials/github-pages-tutorial.md
+++ b/web/tutorials/github-pages-tutorial.md
@@ -66,8 +66,7 @@ config = defaultConfiguration
   }
 
 main :: IO ()
-main = do
-  hakyllWith config $ do
+main = hakyllWith config $ do
   ...
 ```
 


### PR DESCRIPTION
There is an extraneous `do` block surrounding `hakyllWith`.
Removing it allows `site.hs` to compile successfully. Just a small fix.