### PR TITLE
Async runtime with graph-based dependency cycle checks

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -183,6 +183,7 @@ Library
     filepath             >= 1.0      && < 1.5,
     hashable             >= 1.0      && < 2,
     lifted-async         >= 0.10     && < 1,
+    lifted-base          >= 0.2      && < 1,
     lrucache             >= 1.1.1    && < 1.3,
     mtl                  >= 1        && < 2.3,
     network-uri          >= 2.6      && < 2.7,

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -183,7 +183,6 @@ Library
     filepath             >= 1.0      && < 1.5,
     hashable             >= 1.0      && < 2,
     lifted-async         >= 0.10     && < 1,
-    lifted-base          >= 0.2      && < 1,
     lrucache             >= 1.1.1    && < 1.3,
     mtl                  >= 1        && < 2.3,
     network-uri          >= 2.6      && < 2.7,

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -169,6 +169,7 @@ Library
     Paths_hakyll
 
   Build-Depends:
+    array                >= 0.5      && < 1,
     base                 >= 4.8      && < 5,
     binary               >= 0.5      && < 0.10,
     blaze-html           >= 0.5      && < 0.10,
@@ -181,6 +182,7 @@ Library
     file-embed           >= 0.0.10.1 && < 0.0.14,
     filepath             >= 1.0      && < 1.5,
     hashable             >= 1.0      && < 2,
+    lifted-async         >= 0.10     && < 1,
     lrucache             >= 1.1.1    && < 1.3,
     mtl                  >= 1        && < 2.3,
     network-uri          >= 2.6      && < 2.7,
@@ -191,6 +193,7 @@ Library
     regex-tdfa           >= 1.1      && < 1.4,
     resourcet            >= 1.1      && < 1.3,
     scientific           >= 0.3.4    && < 0.4,
+    stm                  >= 2.3      && < 3,
     tagsoup              >= 0.13.1   && < 0.15,
     template-haskell     >= 2.14     && < 2.17,
     text                 >= 0.11     && < 1.3,

--- a/lib/Hakyll/Core/Runtime.hs
+++ b/lib/Hakyll/Core/Runtime.hs
@@ -5,19 +5,24 @@ module Hakyll.Core.Runtime
 
 
 --------------------------------------------------------------------------------
-import           Control.Monad                 (unless)
-import           Control.Monad.Except          (ExceptT, runExceptT, throwError)
-import           Control.Monad.Reader          (ask)
-import           Control.Monad.RWS             (RWST, runRWST)
-import           Control.Monad.State           (get, modify)
-import           Control.Monad.Trans           (liftIO)
-import           Data.List                     (intercalate)
-import           Data.Map                      (Map)
-import qualified Data.Map                      as M
-import           Data.Set                      (Set)
-import qualified Data.Set                      as S
-import           System.Exit                   (ExitCode (..))
-import           System.FilePath               ((</>))
+import           Control.Concurrent.Async.Lifted (forConcurrently_)
+import           Control.Concurrent.STM          (atomically, modifyTVar', readTVarIO, newTVarIO, TVar)
+import           Control.Monad                   (unless)
+import           Control.Monad.Except            (ExceptT, runExceptT, throwError)
+import           Control.Monad.Reader            (ask)
+import           Control.Monad.RWS               (RWST, runRWST)
+import           Control.Monad.State             (get)          
+import           Control.Monad.Trans             (liftIO)
+import qualified Data.Array                      as A
+import           Data.Graph                      (Graph)
+import qualified Data.Graph                      as G
+import           Data.List                       (intercalate)
+import           Data.Map                        (Map)
+import qualified Data.Map                        as M
+import           Data.Set                        (Set)
+import qualified Data.Set                        as S
+import           System.Exit                     (ExitCode (..))
+import           System.FilePath                 ((</>))
 
 
 --------------------------------------------------------------------------------
@@ -67,12 +72,8 @@ run config logger rules = do
             , runtimeRoutes        = rulesRoutes ruleSet
             , runtimeUniverse      = M.fromList compilers
             }
-        state     = RuntimeState
-            { runtimeDone      = S.empty
-            , runtimeSnapshots = S.empty
-            , runtimeTodo      = M.empty
-            , runtimeFacts     = oldFacts
-            }
+
+    state <- newTVarIO $ RuntimeState S.empty S.empty M.empty oldFacts M.empty
 
     -- Run the program and fetch the resulting state
     result <- runExceptT $ runRWST build read' state
@@ -83,7 +84,8 @@ run config logger rules = do
             return (ExitFailure 1, ruleSet)
 
         Right (_, s, _) -> do
-            Store.set store factsKey $ runtimeFacts s
+            facts <- fmap runtimeFacts . liftIO . readTVarIO $ s
+            Store.set store factsKey facts
 
             Logger.debug logger "Removing tmp directory..."
             removeDirectory $ tmpDirectory config
@@ -107,15 +109,25 @@ data RuntimeRead = RuntimeRead
 
 --------------------------------------------------------------------------------
 data RuntimeState = RuntimeState
-    { runtimeDone      :: Set Identifier
-    , runtimeSnapshots :: Set (Identifier, Snapshot)
-    , runtimeTodo      :: Map Identifier (Compiler SomeItem)
-    , runtimeFacts     :: DependencyFacts
+    { runtimeDone         :: Set Identifier
+    , runtimeSnapshots    :: Set (Identifier, Snapshot)
+    , runtimeTodo         :: Map Identifier (Compiler SomeItem)
+    , runtimeFacts        :: DependencyFacts
+    , runtimeDependencies :: Map Identifier (Set Identifier)
     }
 
 
 --------------------------------------------------------------------------------
-type Runtime a = RWST RuntimeRead () RuntimeState (ExceptT String IO) a
+type Runtime a = RWST RuntimeRead () (TVar RuntimeState) (ExceptT String IO) a
+
+
+--------------------------------------------------------------------------------
+-- Because compilation of rules often revolves around IO,
+-- it is not possible to live in the STM monad and hence benefit from
+-- its guarantees.
+-- Be very careful when modifying the state
+modifyRuntimeState :: (RuntimeState -> RuntimeState) -> Runtime ()
+modifyRuntimeState f = get >>= \s -> liftIO . atomically $ modifyTVar' s f
 
 
 --------------------------------------------------------------------------------
@@ -135,13 +147,15 @@ scheduleOutOfDate = do
     logger   <- runtimeLogger   <$> ask
     provider <- runtimeProvider <$> ask
     universe <- runtimeUniverse <$> ask
-    facts    <- runtimeFacts    <$> get
-    todo     <- runtimeTodo     <$> get
 
     let identifiers = M.keys universe
         modified    = S.fromList $ flip filter identifiers $
             resourceModified provider
-
+    
+    state <- liftIO . readTVarIO =<< get
+    let facts = runtimeFacts state
+        todo  = runtimeTodo state
+        
     let (ood, facts', msgs) = outOfDate identifiers modified facts
         todo'               = M.filterWithKey
             (\id' _ -> id' `S.member` ood) universe
@@ -150,7 +164,7 @@ scheduleOutOfDate = do
     mapM_ (Logger.debug logger) msgs
 
     -- Update facts and todo items
-    modify $ \s -> s
+    modifyRuntimeState $ \s -> s
         { runtimeDone  = runtimeDone s `S.union`
             (S.fromList identifiers `S.difference` ood)
         , runtimeTodo  = todo `M.union` todo'
@@ -161,116 +175,138 @@ scheduleOutOfDate = do
 --------------------------------------------------------------------------------
 pickAndChase :: Runtime ()
 pickAndChase = do
-    todo <- runtimeTodo <$> get
-    case M.minViewWithKey todo of
-        Nothing            -> return ()
-        Just ((id', _), _) -> do
-            chase [] id'
-            pickAndChase
+    todo <- fmap runtimeTodo . liftIO . readTVarIO =<< get
+    unless (null todo) $ do
+        checkForDependencyCycle
+        forConcurrently_ (M.keys todo) chase
+        pickAndChase
 
 
 --------------------------------------------------------------------------------
-chase :: [Identifier] -> Identifier -> Runtime ()
-chase trail id'
-    | id' `elem` trail = throwError $ "Hakyll.Core.Runtime.chase: " ++
-        "Dependency cycle detected: " ++ intercalate " depends on "
-            (map show $ dropWhile (/= id') (reverse trail) ++ [id'])
-    | otherwise        = do
-        logger   <- runtimeLogger        <$> ask
-        todo     <- runtimeTodo          <$> get
-        provider <- runtimeProvider      <$> ask
-        universe <- runtimeUniverse      <$> ask
-        routes   <- runtimeRoutes        <$> ask
-        store    <- runtimeStore         <$> ask
-        config   <- runtimeConfiguration <$> ask
-        Logger.debug logger $ "Processing " ++ show id'
+-- | Check for cyclic dependencies in the current state
+checkForDependencyCycle :: Runtime ()
+checkForDependencyCycle = do
+    deps <- fmap runtimeDependencies . liftIO . readTVarIO =<< get
+    let (depgraph, nodeFromVertex, _) = G.graphFromEdges [(k, k, S.toList dps) | (k, dps) <- M.toList deps]
+        dependencyCycles = map ((\(_, k, _) -> k) . nodeFromVertex) $ cycles depgraph
 
-        let compiler = todo M.! id'
-            read' = CompilerRead
-                { compilerConfig     = config
-                , compilerUnderlying = id'
-                , compilerProvider   = provider
-                , compilerUniverse   = M.keysSet universe
-                , compilerRoutes     = routes
-                , compilerStore      = store
-                , compilerLogger     = logger
+    unless (null dependencyCycles) $ do
+        throwError $ "Hakyll.Core.Runtime.pickAndChase: " ++
+            "Dependency cycle detected: " ++ intercalate ", " (map show dependencyCycles) ++
+            " are inter-dependent."
+    where
+        cycles :: Graph -> [G.Vertex]
+        cycles g = map fst . filter (uncurry $ reachableFromAny g) . A.assocs $ g
+
+        reachableFromAny :: Graph -> G.Vertex -> [G.Vertex] -> Bool
+        reachableFromAny graph node = elem node . concatMap (G.reachable graph)
+
+
+--------------------------------------------------------------------------------
+chase :: Identifier -> Runtime ()
+chase id' = do
+    logger    <- runtimeLogger        <$> ask
+    provider  <- runtimeProvider      <$> ask
+    universe  <- runtimeUniverse      <$> ask
+    routes    <- runtimeRoutes        <$> ask
+    store     <- runtimeStore         <$> ask
+    config    <- runtimeConfiguration <$> ask
+
+    state     <- liftIO . readTVarIO =<< get
+
+    Logger.debug logger $ "Processing " ++ show id'
+
+    let compiler = (runtimeTodo state) M.! id'
+        read' = CompilerRead
+            { compilerConfig     = config
+            , compilerUnderlying = id'
+            , compilerProvider   = provider
+            , compilerUniverse   = M.keysSet universe
+            , compilerRoutes     = routes
+            , compilerStore      = store
+            , compilerLogger     = logger
+            }
+
+    result <- liftIO $ runCompiler compiler read'
+    case result of
+        -- Rethrow error
+        CompilerError e -> throwError $ case compilerErrorMessages e of
+            [] -> "Compiler failed but no info given, try running with -v?"
+            es -> intercalate "; " es
+
+        -- Signal that a snapshot was saved ->
+        CompilerSnapshot snapshot c -> do
+            -- Update info. The next 'chase' will pick us again at some
+            -- point so we can continue then.
+            modifyRuntimeState $ \s -> s
+                { runtimeSnapshots = S.insert (id', snapshot) (runtimeSnapshots s)
+                , runtimeTodo      = M.insert id' c (runtimeTodo s)
                 }
 
-        result <- liftIO $ runCompiler compiler read'
-        case result of
-            -- Rethrow error
-            CompilerError e -> throwError $ case compilerErrorMessages e of
-                [] -> "Compiler failed but no info given, try running with -v?"
-                es -> intercalate "; " es
 
-            -- Signal that a snapshot was saved ->
-            CompilerSnapshot snapshot c -> do
-                -- Update info. The next 'chase' will pick us again at some
-                -- point so we can continue then.
-                modify $ \s -> s
-                    { runtimeSnapshots =
-                        S.insert (id', snapshot) (runtimeSnapshots s)
-                    , runtimeTodo      = M.insert id' c (runtimeTodo s)
-                    }
+        -- Huge success
+        CompilerDone (SomeItem item) cwrite -> do
+            -- Print some info
+            let facts = compilerDependencies cwrite
+                cacheHits
+                    | compilerCacheHits cwrite <= 0 = "updated"
+                    | otherwise                     = "cached "
+            Logger.message logger $ cacheHits ++ " " ++ show id'
 
-            -- Huge success
-            CompilerDone (SomeItem item) cwrite -> do
-                -- Print some info
-                let facts = compilerDependencies cwrite
-                    cacheHits
-                        | compilerCacheHits cwrite <= 0 = "updated"
-                        | otherwise                     = "cached "
-                Logger.message logger $ cacheHits ++ " " ++ show id'
+            -- Sanity check
+            unless (itemIdentifier item == id') $ throwError $
+                "The compiler yielded an Item with Identifier " ++
+                show (itemIdentifier item) ++ ", but we were expecting " ++
+                "an Item with Identifier " ++ show id' ++ " " ++
+                "(you probably want to call makeItem to solve this problem)"
 
-                -- Sanity check
-                unless (itemIdentifier item == id') $ throwError $
-                    "The compiler yielded an Item with Identifier " ++
-                    show (itemIdentifier item) ++ ", but we were expecting " ++
-                    "an Item with Identifier " ++ show id' ++ " " ++
-                    "(you probably want to call makeItem to solve this problem)"
+            -- Write if necessary
+            (mroute, _) <- liftIO $ runRoutes routes provider id'
+            case mroute of
+                Nothing    -> return ()
+                Just route -> do
+                    let path = destinationDirectory config </> route
+                    liftIO $ makeDirectories path
+                    liftIO $ write path item
+                    Logger.debug logger $ "Routed to " ++ path
 
-                -- Write if necessary
-                (mroute, _) <- liftIO $ runRoutes routes provider id'
-                case mroute of
-                    Nothing    -> return ()
-                    Just route -> do
-                        let path = destinationDirectory config </> route
-                        liftIO $ makeDirectories path
-                        liftIO $ write path item
-                        Logger.debug logger $ "Routed to " ++ path
+            -- Save! (For load)
+            liftIO $ save store item
 
-                -- Save! (For load)
-                liftIO $ save store item
+            modifyRuntimeState $ \s -> s
+                { runtimeDone  = S.insert id' (runtimeDone s)
+                , runtimeTodo  = M.delete id' (runtimeTodo s)
+                , runtimeFacts = M.insert id' facts (runtimeFacts s)
+                }
 
-                -- Update state
-                modify $ \s -> s
-                    { runtimeDone  = S.insert id' (runtimeDone s)
-                    , runtimeTodo  = M.delete id' (runtimeTodo s)
-                    , runtimeFacts = M.insert id' facts (runtimeFacts s)
-                    }
+        -- Try something else first
+        CompilerRequire dep c -> do
+            let (depId, depSnapshot) = dep
+            Logger.debug logger $
+                "Compiler requirement found for: " ++ show id' ++
+                ", requirement: " ++ show depId
 
-            -- Try something else first
-            CompilerRequire dep c -> do
-                -- Update the compiler so we don't execute it twice
-                let (depId, depSnapshot) = dep
-                done      <- runtimeDone <$> get
-                snapshots <- runtimeSnapshots <$> get
+            let done      = runtimeDone state
+                snapshots = runtimeSnapshots state
+                deps      = runtimeDependencies state
 
-                -- Done if we either completed the entire item (runtimeDone) or
-                -- if we previously saved the snapshot (runtimeSnapshots).
-                let depDone =
-                        depId `S.member` done ||
-                        (depId, depSnapshot) `S.member` snapshots
+            -- Done if we either completed the entire item (runtimeDone) or
+            -- if we previously saved the snapshot (runtimeSnapshots).
+            let depDone =
+                    depId `S.member` done ||
+                    (depId, depSnapshot) `S.member` snapshots
 
-                modify $ \s -> s
-                    { runtimeTodo = M.insert id'
-                        (if depDone then c else compilerResult result)
-                        (runtimeTodo s)
-                    }
+            let deps' = if depDone
+                            then deps
+                            else M.insertWith S.union id' (S.singleton depId) deps  
 
-                -- If the required item is already compiled, continue, or, start
-                -- chasing that
-                Logger.debug logger $ "Require " ++ show depId ++
-                    " (snapshot " ++ depSnapshot ++ "): " ++
-                    (if depDone then "OK" else "chasing")
-                if depDone then chase trail id' else chase (id' : trail) depId
+            modifyRuntimeState $ \s -> s
+                { runtimeTodo         = M.insert id' 
+                    (if depDone then c else compilerResult result) 
+                    (runtimeTodo s)
+                , runtimeDependencies = deps'
+                }
+
+            Logger.debug logger $ "Require " ++ show depId ++
+                " (snapshot " ++ depSnapshot ++ ") "
+            

--- a/lib/Hakyll/Core/Runtime.hs
+++ b/lib/Hakyll/Core/Runtime.hs
@@ -5,11 +5,8 @@ module Hakyll.Core.Runtime
 
 
 --------------------------------------------------------------------------------
-import           Control.Concurrent              (getNumCapabilities)
-import           Control.Concurrent.Async.Lifted (mapConcurrently_)
-import           Control.Concurrent.QSemN        (QSemN, newQSemN, signalQSemN, waitQSemN)
+import           Control.Concurrent.Async.Lifted (forConcurrently_)
 import           Control.Concurrent.STM          (atomically, modifyTVar', readTVarIO, newTVarIO, TVar)
-import           Control.Exception.Lifted        (bracket_)
 import           Control.Monad                   (unless)
 import           Control.Monad.Except            (ExceptT, runExceptT, throwError)
 import           Control.Monad.Reader            (ask)
@@ -64,10 +61,6 @@ run config logger rules = do
     mOldFacts <- Store.get store factsKey
     let (oldFacts) = case mOldFacts of Store.Found f -> f
                                        _             -> mempty
-    
-    -- Number of physical cores available for compilation
-    numproc <- getNumCapabilities 
-    Logger.debug logger $ "Using at most " ++ " cores..."
 
     -- Build runtime read/state
     let compilers = rulesCompilers ruleSet
@@ -78,7 +71,6 @@ run config logger rules = do
             , runtimeStore         = store
             , runtimeRoutes        = rulesRoutes ruleSet
             , runtimeUniverse      = M.fromList compilers
-            , runtimeCapabilities  = numproc
             }
 
     state <- newTVarIO $ RuntimeState 
@@ -118,7 +110,6 @@ data RuntimeRead = RuntimeRead
     , runtimeStore         :: Store
     , runtimeRoutes        :: Routes
     , runtimeUniverse      :: Map Identifier (Compiler SomeItem)
-    , runtimeCapabilities  :: Int
     }
 
 
@@ -195,24 +186,11 @@ scheduleOutOfDate = do
 --------------------------------------------------------------------------------
 pickAndChase :: Runtime ()
 pickAndChase = do
-    numproc <- runtimeCapabilities <$> ask
     todo <- runtimeTodo <$> getRuntimeState
     unless (null todo) $ do
         checkForDependencyCycle
-        mapConcurrentlyN_ numproc chase (M.keys todo)
+        forConcurrently_ (M.keys todo) chase
         pickAndChase
-
-
---------------------------------------------------------------------------------
--- | Maps a function and discard the results, performing at most @N@ actions concurrently.
-mapConcurrentlyN_ :: Traversable t => Int -> (a -> Runtime ()) -> t a -> Runtime ()
-mapConcurrentlyN_ n f xs = do
-  -- Emulating a pool of processes with locked access
-  sem <- liftIO $ newQSemN n
-  mapConcurrently_ (with sem . f) xs
-  where
-    with :: QSemN -> Runtime a -> Runtime a
-    with s = bracket_ (liftIO $ waitQSemN s 1) (liftIO $ signalQSemN s 1)
 
 
 --------------------------------------------------------------------------------

--- a/src/Init.hs
+++ b/src/Init.hs
@@ -120,7 +120,7 @@ createCabal path name =
       , "  main-is:          site.hs"
       , "  build-depends:    base == 4.*"
       , "                  , hakyll == " ++ version' ++ ".*"
-      , "  ghc-options:      -threaded"
+      , "  ghc-options:      -threaded -rtsopts -with-rtsopts=-N"
       , "  default-language: Haskell2010"
       ]
   where


### PR DESCRIPTION
Hello,

This is a PR to make hakyll's runtime concurrent. 

The general idea is based on #725. That particular implementation incorrectly identified a dependency cycle [in my personal website](https://github.com/LaurentRDC/personal-website) that did not exist. Hence, this PR includes more robust dependency cycle checking based on `Data.Graph`. A test case has been added to ensure this works.

The concurrency is implemented as follows.
1. Identify all items that need to be compiled;
2. Compile all items concurrently. Items that compiled successfully are removed from the todo list, while those with dependencies are kept;
3. The remaining todo and their dependencies are checked for cycles in a single thread;
4. Go to step 1 until all items have been compiled.

```haskell
pickAndChase :: Runtime ()
pickAndChase = do
    todo <- fmap runtimeTodo . liftIO . readTVarIO =<< get
    unless (null todo) $ do
        checkForDependencyCycle
        forConcurrently_ (M.keys todo) chase
        pickAndChase
```

The advantage of this implementation is that it is easy to swap between concurrent/serial by simply swapping `forConcurrently_` for `forM_`. Maybe we can offer this option as a compile flag?

I have tested this version of hakyll on my personal page and I'm very satisfied with the results.

closes #714 
