### PR TITLE
Docs: IRC channel moved from Freenode to Libera.Chat

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -22,7 +22,7 @@ Description:
 
   .
 
-  * An IRC channel, @#hakyll@ on freenode
+  * An IRC channel, @#hakyll@ on irc.libera.chat (we *do not* have a channel on Freenode anymore)
 
   .
 

--- a/web/index.markdown
+++ b/web/index.markdown
@@ -39,4 +39,5 @@ using [stack] by using `stack install hakyll`. Then, you can:
 - read the [tutorials](/tutorials.html);
 - mail the [google discussion group](http://groups.google.com/group/hakyll);
 - ask questions on the IRC channel: `#hakyll` on
-  [freenode](http://freenode.net/).
+  [irc.libera.chat](https://libera.chat/) (we *do not* have a channel on
+  Freenode anymore).

--- a/web/templates/tutorial.html
+++ b/web/templates/tutorial.html
@@ -18,4 +18,5 @@ you have a github account, you can use the
 
 If you run into any problems, all questions are welcome in the above google
 group, or you could try the IRC channel, <code>#hakyll</code> on
-<a href="http://freenode.net/">freenode</a>.
+<a href="https://libera.chat/">irs.libera.chat</a> (we <em>do not</em> have
+a channel on Freenode anymore).


### PR DESCRIPTION
There's no mention of this on the issue tracker, so here's my recap of
what led to this change.

There is some drama around Freenode. Their volunteer staff quit[1]. Then
the new-ish management started enacting strange policy changes[2] and
take over the channels[3]. On June 26th 2021 Freenode's bot tried to
take over #hakyll, but failed; however, it did succeed in #haskell and
many, many other channels.

For the preceding week, me and IRC user henk were trying to move the
channel off the Freenode, either to Libera.Chat or OFTC. Jasper, the
founder of Hakyll, was absent from IRC and didn't respond to my emails.
Me and henk are the most active IRC users on the channel. Also, I have
Collaborator access to the repo, and henk has chanop access to the IRC
channel. We believe that at this time, we're the ones who are the best
positioned to execute the move, so we're doing it.

We only considered Libera.Chat and OFTC. Libera.Chat was created a week
earlier by the same staff who quit Freenode; I personally consider them
to be a spiritual successor of Freenode. OFTC is a well-established
network with good governance documentation. Both networks are
FOSS-friendly. The choice wasn't obvious.

Libera.Chat was picked because 10 users moved there (and 1 more did
while I was typing this!), whereas only 2 joined OFTC (me and henk, and
those weren't votes for OFTC — we were just ensuring that the channel is
ours). Also, #haskell and #ghc are on Libera too, so it makes sense for
a Haskell project such as Hakyll to be present on Libera.

For posterity:

<Minoru> info #hakyll
-ChanServ(ChanServ@services.)- Information on #hakyll:
-ChanServ(ChanServ@services.)- Founder    : jaspervdj
-ChanServ(ChanServ@services.)- Registered : Mar 01 13:29:17 2011 (10y 12w 5d ago)
-ChanServ(ChanServ@services.)- Mode lock  : +ntc-slk
-ChanServ(ChanServ@services.)- *** End of Info ***

1. https://kline.sh
2. https://github.com/freenode/web-7.0/pull/513
3. https://www.devever.net/~hl/freenode_abuse