### PR TITLE
Allow excluding dirs from being watched

### DIFF
--- a/lib/Hakyll/Commands.hs
+++ b/lib/Hakyll/Commands.hs
@@ -77,7 +77,7 @@ preview :: Configuration -> Logger -> Rules a -> Int -> IO ()
 #ifdef PREVIEW_SERVER
 preview conf logger rules port  = do
     deprecatedMessage
-    watch conf logger "0.0.0.0" port True rules
+    watch conf logger "0.0.0.0" port True [] rules
   where
     deprecatedMessage = mapM_ putStrLn [ "The preview command has been deprecated."
                                        , "Use the watch command for recompilation and serving."
@@ -90,15 +90,15 @@ preview _ _ _ _ = previewServerDisabled
 --------------------------------------------------------------------------------
 -- | Watch and recompile for changes
 
-watch :: Configuration -> Logger -> String -> Int -> Bool -> Rules a -> IO ()
+watch :: Configuration -> Logger -> String -> Int -> Bool -> [FilePath] -> Rules a -> IO ()
 #ifdef WATCH_SERVER
-watch conf logger host port runServer rules = do
+watch conf logger host port runServer excludedDirs rules = do
 #ifndef mingw32_HOST_OS
-    _ <- forkIO $ watchUpdates conf update
+    _ <- forkIO $ watchUpdates conf excludedDirs update
 #else
     -- Force windows users to compile with -threaded flag, as otherwise
     -- thread is blocked indefinitely.
-    catchIOError (void $ forkOS $ watchUpdates conf update) $ \_ -> do
+    catchIOError (void $ forkOS $ watchUpdates conf excludedDirs update) $ \_ -> do
         fail $ "Hakyll.Commands.watch: Could not start update watching " ++
                "thread. Did you compile with -threaded flag?"
 #endif

--- a/lib/Hakyll/Core/Util/Parser.hs
+++ b/lib/Hakyll/Core/Util/Parser.hs
@@ -2,15 +2,17 @@
 -- | Parser utilities
 module Hakyll.Core.Util.Parser
     ( metadataKey
+    , directories
     ) where
 
 
 --------------------------------------------------------------------------------
-import           Control.Applicative ((<|>))
-import           Control.Monad       (guard, mzero, void)
-import qualified Text.Parsec         as P
-import           Text.Parsec.String  (Parser)
-
+import           Control.Applicative    ((<|>))
+import           Control.Monad          (guard, mzero, void)
+import qualified Text.Parsec            as P
+import qualified Text.Parsec.Char       as PC
+import qualified Text.Parsec.Combinator as PCO
+import           Text.Parsec.String     (Parser)
 
 --------------------------------------------------------------------------------
 metadataKey :: Parser String
@@ -29,3 +31,18 @@ metadataKey = do
 --------------------------------------------------------------------------------
 reservedKeys :: [String]
 reservedKeys = ["if", "else", "endif", "for", "sep", "endfor", "partial"]
+
+
+--------------------------------------------------------------------------------
+directories :: Parser [FilePath]
+directories =
+    -- Parses {dir1,dir2,dir3}
+    PCO.between
+        (PC.char '{')
+        (PC.char '}')
+        ( PCO.many1 (PC.satisfy (\ch -> ch /= ',' && ch /= '}'))
+            `PCO.sepBy` PC.char ','
+        )
+        <* PCO.eof
+        -- Parses single dir
+        <|> return <$> PCO.many1 PC.anyChar


### PR DESCRIPTION
https://github.com/jaspervdj/hakyll/issues/845

Add a CLI argument (`--exclude-dir="dir"`, `--exclude-dir="{dir1,dir2,dir3}"`) to watch-mode to remove events originating from these directories, effectively excluding them from being watched.

This can be used to preprocess files in watch mode.