### PR TITLE
Bump some more dependencies

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -179,7 +179,7 @@ Library
     data-default         >= 0.4      && < 0.8,
     deepseq              >= 1.3      && < 1.5,
     directory            >= 1.2.7.0  && < 1.4,
-    file-embed           >= 0.0.10.1 && < 0.0.14,
+    file-embed           >= 0.0.10.1 && < 0.0.15,
     filepath             >= 1.0      && < 1.5,
     hashable             >= 1.0      && < 2,
     lifted-async         >= 0.10     && < 1,

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -197,7 +197,7 @@ Library
     tagsoup              >= 0.13.1   && < 0.15,
     template-haskell     >= 2.14     && < 2.17,
     text                 >= 0.11     && < 1.3,
-    time                 >= 1.8      && < 1.10,
+    time                 >= 1.8      && < 1.12,
     time-locale-compat   >= 0.1      && < 0.2,
     unordered-containers >= 0.2      && < 0.3,
     vector               >= 0.11     && < 0.13,

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -195,7 +195,7 @@ Library
     scientific           >= 0.3.4    && < 0.4,
     stm                  >= 2.3      && < 3,
     tagsoup              >= 0.13.1   && < 0.15,
-    template-haskell     >= 2.14     && < 2.17,
+    template-haskell     >= 2.14     && < 2.18,
     text                 >= 0.11     && < 1.3,
     time                 >= 1.8      && < 1.12,
     time-locale-compat   >= 0.1      && < 0.2,


### PR DESCRIPTION
This builds with GHC 9 as `cabal build --enable-tests --constrain 'template-haskell == 2.17.0.0' --constrain 'time == 1.11.1.2' --constrain 'file-embed == 0.0.14.0' `, and tests pass too.