### PR TITLE
CI: migrate to haskell/actions/setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.4
+    - uses: haskell/actions/setup@v1.2.1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.4
+    - uses: haskell/actions/setup@v1.2.1
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
actions/haskell-setup are no longer maintained by GitHub and have been
archived. haskell/actions/setup is a maintained fork.