### PR TITLE
add 'forceCompile' rules modifier

### DIFF
--- a/lib/Hakyll/Core/Rules.hs
+++ b/lib/Hakyll/Core/Rules.hs
@@ -29,6 +29,7 @@ module Hakyll.Core.Rules
     , preprocess
     , Dependency (..)
     , rulesExtraDependencies
+    , forceCompile
     ) where
 
 
@@ -221,3 +222,11 @@ rulesExtraDependencies deps rules =
             | (i, c) <- rulesCompilers ruleSet
             ]
         }
+
+
+--------------------------------------------------------------------------------
+-- | Force the item(s) to always be recompiled, whether or not the
+-- dependencies are out of date.  This can be useful if you are using
+-- I/O to generate part (or all) of an item.
+forceCompile :: Rules a -> Rules a
+forceCompile = rulesExtraDependencies [AlwaysOutOfDate]


### PR DESCRIPTION
Compilers that use data from sources other than local files may need
to be recompiled, but Hakyll's file-based dependency checking does
not handle this situation.

Add a new kind of dependency called 'AlwaysOutOfDate'.  If an item
has this dependency, it will be unconditionally rebuilt.

Also add the 'forceCompile' rule modifier, which is a user-friendly
way to force recompilation of specific items.  Example usage:

    forceCompile $ create ["foo"] $ do
        route $ idRoute
        compile $ unsafeCompiler $ doSomeIO