### PR TITLE
Updated pandoc to 2.14.0.3. Bumped minor version.

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -1,5 +1,5 @@
 Name:    hakyll
-Version: 4.14.0.0
+Version: 4.14.0.1
 
 Synopsis: A static website compiler library
 Description:
@@ -239,7 +239,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.15
+      pandoc >= 2.14.0.3 && < 2.15
     Cpp-options:
       -DUSE_PANDOC
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,3 @@
-# resolver: lts-18.0
 resolver: nightly-2021-06-30
 save-hackage-creds: false
 system-ghc: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
-resolver: lts-17.5
+# resolver: lts-18.0
+resolver: nightly-2021-06-30
 save-hackage-creds: false
 system-ghc: true
 skip-ghc-check: true

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 565266
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/5.yaml
-    sha256: 78e8ebabf11406261abbc95b44f240acf71802630b368888f6d758de7fc3a2f7
-  original: lts-17.5
+    size: 534951
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/6/30.yaml
+    sha256: 2afa1a6a0d8b56347263130a10b7eee5c2fe212d0126276a99f21cd0fc62bbf1
+  original: nightly-2021-06-30


### PR DESCRIPTION
I hope this is ok. I've needed to bump pandoc to the latest version, in order to [have syntax highlighting for Swift](https://github.com/jgm/skylighting/pull/128). Seems to pose no issues or conflicts with Hakyll, but it does currently require a nightly LTS to build with stack, so it might not be wanted.