### PR TITLE
Avoid "Empty 'do' block" error in GitHub tutorial

### DIFF
--- a/web/tutorials/github-pages-tutorial.md
+++ b/web/tutorials/github-pages-tutorial.md
@@ -66,8 +66,7 @@ config = defaultConfiguration
   }
 
 main :: IO ()
-main = do
-  hakyllWith config $ do
+main = hakyllWith config $ do
   ...
 ```
 


### PR DESCRIPTION
Report and fix by @alexandroid000. Fixes #860.