### PR TITLE
Supporting different field names for tags.

### DIFF
--- a/lib/Hakyll/Web/Tags.hs
+++ b/lib/Hakyll/Web/Tags.hs
@@ -112,11 +112,11 @@ getTags = getTagsByField "tags"
 -- | Obtain tags from a page by name of the metadata field. These can be a list
 -- or a comma-separated string
 getTagsByField :: MonadMetadata m => String -> Identifier -> m [String]
-getTagsByField field identifier = do
+getTagsByField fieldName identifier = do
     metadata <- getMetadata identifier
     return $ fromMaybe [] $
-        (lookupStringList field metadata) `mplus`
-        (map trim . splitAll "," <$> lookupString field metadata)
+        (lookupStringList fieldName metadata) `mplus`
+        (map trim . splitAll "," <$> lookupString fieldName metadata)
 
 
 --------------------------------------------------------------------------------
@@ -148,11 +148,6 @@ buildTagsWith f pattern makeId = do
 --------------------------------------------------------------------------------
 buildTags :: MonadMetadata m => Pattern -> (String -> Identifier) -> m Tags
 buildTags = buildTagsWith getTags
-
-
---------------------------------------------------------------------------------
-buildTagsByField :: MonadMetadata m => String -> Pattern -> (String -> Identifier) -> m Tags
-buildTagsByField field = buildTagsWith (getTagsByField field)
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Web/Tags.hs
+++ b/lib/Hakyll/Web/Tags.hs
@@ -43,9 +43,11 @@
 module Hakyll.Web.Tags
     ( Tags (..)
     , getTags
+    , getTagsByField
     , getCategory
     , buildTagsWith
     , buildTags
+    , buildTagsByField
     , buildCategories
     , tagsRules
     , renderTags
@@ -105,11 +107,16 @@ data Tags = Tags
 -- | Obtain tags from a page in the default way: parse them from the @tags@
 -- metadata field. This can either be a list or a comma-separated string.
 getTags :: MonadMetadata m => Identifier -> m [String]
-getTags identifier = do
+getTags = getTagsByField "tags"
+
+-- | Obtain tags from a page by name of the metadata field. These can be a list
+-- or a comma-separated string
+getTagsByField :: MonadMetadata m => String -> Identifier -> m [String]
+getTagsByField field identifier = do
     metadata <- getMetadata identifier
     return $ fromMaybe [] $
-        (lookupStringList "tags" metadata) `mplus`
-        (map trim . splitAll "," <$> lookupString "tags" metadata)
+        (lookupStringList field metadata) `mplus`
+        (map trim . splitAll "," <$> lookupString field metadata)
 
 
 --------------------------------------------------------------------------------
@@ -141,6 +148,11 @@ buildTagsWith f pattern makeId = do
 --------------------------------------------------------------------------------
 buildTags :: MonadMetadata m => Pattern -> (String -> Identifier) -> m Tags
 buildTags = buildTagsWith getTags
+
+
+--------------------------------------------------------------------------------
+buildTagsByField :: MonadMetadata m => String -> Pattern -> (String -> Identifier) -> m Tags
+buildTagsByField field = buildTagsWith (getTagsByField field)
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Web/Tags.hs
+++ b/lib/Hakyll/Web/Tags.hs
@@ -47,7 +47,6 @@ module Hakyll.Web.Tags
     , getCategory
     , buildTagsWith
     , buildTags
-    , buildTagsByField
     , buildCategories
     , tagsRules
     , renderTags


### PR DESCRIPTION
Recently had a situation where we wanted two separate fields for tags, one for a simple tag cloud and another for a more robust index of keywords, and implemented these in our site generator. This just refactors `getTags` and `buildTags` to easily allow users to pick an arbitrary field for tag-like data without needing to peek into the source. 