### PR TITLE
Hakyll.Core.Runtime: use `MVar` instead of `TVar`

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -193,7 +193,6 @@ Library
     regex-tdfa           >= 1.1      && < 1.4,
     resourcet            >= 1.1      && < 1.3,
     scientific           >= 0.3.4    && < 0.4,
-    stm                  >= 2.3      && < 3,
     tagsoup              >= 0.13.1   && < 0.15,
     template-haskell     >= 2.14     && < 2.18,
     text                 >= 0.11     && < 1.3,


### PR DESCRIPTION
Proposing a slightly different choice of concurrent variable type to https://github.com/jaspervdj/hakyll/pull/844.