### PR TITLE
add support for OpenGraph and JSON-LD metadata

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -146,6 +146,8 @@ Library
     Hakyll.Web.Feed
     Hakyll.Web.Html
     Hakyll.Web.Html.RelativizeUrls
+    Hakyll.Web.Meta.OpenGraph
+    Hakyll.Web.Meta.TwitterCard
     Hakyll.Web.Paginate
     Hakyll.Web.Redirect
     Hakyll.Web.Tags

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -146,6 +146,7 @@ Library
     Hakyll.Web.Feed
     Hakyll.Web.Html
     Hakyll.Web.Html.RelativizeUrls
+    Hakyll.Web.Meta.JSONLD
     Hakyll.Web.Meta.OpenGraph
     Hakyll.Web.Meta.TwitterCard
     Hakyll.Web.Paginate
@@ -171,6 +172,7 @@ Library
     Paths_hakyll
 
   Build-Depends:
+    aeson                >= 1.0      && < 1.6,
     array                >= 0.5      && < 1,
     base                 >= 4.8      && < 5,
     binary               >= 0.5      && < 0.10,

--- a/lib/Hakyll.hs
+++ b/lib/Hakyll.hs
@@ -20,6 +20,9 @@ module Hakyll
     , module Hakyll.Web.Feed
     , module Hakyll.Web.Html
     , module Hakyll.Web.Html.RelativizeUrls
+    , module Hakyll.Web.Meta.JSONLD
+    , module Hakyll.Web.Meta.OpenGraph
+    , module Hakyll.Web.Meta.TwitterCard
     , module Hakyll.Web.Paginate
 #ifdef USE_PANDOC
     , module Hakyll.Web.Pandoc
@@ -53,6 +56,9 @@ import           Hakyll.Web.CompressCss
 import           Hakyll.Web.Feed
 import           Hakyll.Web.Html
 import           Hakyll.Web.Html.RelativizeUrls
+import           Hakyll.Web.Meta.JSONLD
+import           Hakyll.Web.Meta.OpenGraph
+import           Hakyll.Web.Meta.TwitterCard
 import           Hakyll.Web.Paginate
 #ifdef USE_PANDOC
 import           Hakyll.Web.Pandoc

--- a/lib/Hakyll/Web/Meta/JSONLD.hs
+++ b/lib/Hakyll/Web/Meta/JSONLD.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+
+JSON-LD metadata, using <https://schema.org/ Schema.org> vocabulary
+for articles.  Google applications and other search engines use
+these data to improve search results and links.
+
+This implementation supports the following fields:
+
++-------------------+----------------------------------------------------+
+| @\@type@          | __Hardcoded__ value @\"Article"@.                  |
++-------------------+----------------------------------------------------+
+| @headline@        | __Required__ taken from context field @title@.     |
++-------------------+----------------------------------------------------+
+| @datePublished@   | __Required__ date of publication, via 'dateField'. |
++-------------------+----------------------------------------------------+
+
+To use, add a 'jsonldField' to your template context:
+
+@
+let
+  context = 'defaultContext' <> …
+  postContext =
+    context
+    <> 'jsonldField' "jsonld" context
+@
+
+And update the template:
+
+@
+\<head>
+  \<title>$title$\</title>
+  \<link rel="stylesheet" type="text\/css" href="\/css\/default.css" />
+  $if(jsonld)$$jsonld("embed")$$endif$
+\</head>
+@
+
+The @"embed"@ argument generates a @\<script …>@ tag to be directly
+included in page HTML.  To get the raw JSON string, use @"raw"@
+instead.
+
+-}
+module Hakyll.Web.Meta.JSONLD
+  ( jsonldField
+  ) where
+
+import Data.Aeson ((.=), pairs)
+import Data.Aeson.Encoding (encodingToLazyByteString)
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Encoding as LT
+
+import Hakyll
+import Hakyll.Core.Compiler.Internal
+
+runContext :: Context String -> String -> Compiler String
+runContext ctx k = do
+  i <- makeItem "dummy"
+  unContext ctx k [] i >>= \cf -> case cf of
+    StringField s -> pure s
+    _             -> fail $ "Error: '" <> k <> "' is not a StringField"
+
+getContext :: Context String -> String -> Compiler String
+getContext ctx k = compilerTry (runContext ctx k) >>= either f pure
+  where
+  f (CompilationNoResult _) = compilerResult . CompilerError . CompilationFailure . pure $
+                              "missing required field '" <> k <> "'"
+  f err = compilerResult (CompilerError err)
+
+-- This may come in handy later
+_lookupContext :: Context String -> String -> Compiler (Maybe String)
+_lookupContext ctx k = compilerTry (runContext ctx k) >>= either f (pure . Just)
+  where
+  f (CompilationNoResult _) = pure Nothing
+  f err = compilerResult (CompilerError err)
+
+-- | Render JSON-LD for an article.
+-- Requires context with "title", and the item must be able to yield
+-- a valid date via 'getItemUTC'
+--
+renderJSONLD :: Context String -> Compiler (Item String)
+renderJSONLD ctx = do
+  dateString <- getContext (dateField "" "%Y-%m-%dT%H:%M:%S") ""
+  titleString <- getContext ctx "title"
+
+  let
+    obj = pairs $
+      "@context" .= ("https://schema.org" :: String)
+      <> "@type" .= ("Article" :: String)
+      <> "headline" .= titleString
+      <> "datePublished" .= dateString
+
+  makeItem . LT.unpack . LT.decodeUtf8 . encodingToLazyByteString $ obj
+
+jsonldField :: String -> Context String -> Context String
+jsonldField k ctx = functionField k (\args _i -> go args)
+  where
+  -- The zero argument case cannot be a compiler error,
+  -- otherwise @$if(k)$@ evaluates false.
+  go [] = pure $ "<!-- Whoops! Try this instead: $if(" <> k <> ")$$" <> k <> "(\"embed\")$$endif$ -->"
+  go ["raw"] = itemBody <$> renderJSONLD ctx
+  go ["embed"] = do
+    template <- jsonldTemplate
+    i <- renderJSONLD ctx >>= applyTemplate template (bodyField "body")
+    pure $ itemBody i
+  go [_] = fail $ "invalid argument to jsonldField '" <> k <> "'. use \"raw\" or \"embed\""
+  go _ = fail $ "too many arguments to jsonldField '" <> k <> "'"
+
+jsonldTemplate :: Compiler Template
+jsonldTemplate = do
+  makeItem "<script type=\"application/ld+json\">$body$</script>"
+  >>= compileTemplateItem

--- a/lib/Hakyll/Web/Meta/JSONLD.hs
+++ b/lib/Hakyll/Web/Meta/JSONLD.hs
@@ -50,8 +50,11 @@ import Data.Aeson.Encoding (encodingToLazyByteString)
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LT
 
-import Hakyll
+import Hakyll.Core.Compiler
 import Hakyll.Core.Compiler.Internal
+import Hakyll.Core.Item
+import Hakyll.Web.Template
+import Hakyll.Web.Template.Context
 
 runContext :: Context String -> String -> Compiler String
 runContext ctx k = do

--- a/lib/Hakyll/Web/Meta/OpenGraph.hs
+++ b/lib/Hakyll/Web/Meta/OpenGraph.hs
@@ -43,7 +43,10 @@ module Hakyll.Web.Meta.OpenGraph
   ( openGraphField
   ) where
 
-import Hakyll
+import Hakyll.Core.Compiler
+import Hakyll.Core.Item
+import Hakyll.Web.Template
+import Hakyll.Web.Template.Context
 
 openGraphField :: String -> Context String -> Context String
 openGraphField k ctx = functionField k $ \_args i -> do

--- a/lib/Hakyll/Web/Meta/OpenGraph.hs
+++ b/lib/Hakyll/Web/Meta/OpenGraph.hs
@@ -1,0 +1,68 @@
+{- |
+
+Open Graph metadata, as described at <https://ogp.me/>.  This
+implementation supports the following properties:
+
++------------------+----------------------------------------------------+
+| @og:type@        | __Hardcoded__ value @"article"@                    |
++------------------+----------------------------------------------------+
+| @og:url@         | __Required__ concatenation of @root@ and @url@     |
+|                  | context fields, both of which are required.        |
++------------------+----------------------------------------------------+
+| @og:title@       | __Required__ title of article, from @title@ field. |
++------------------+----------------------------------------------------+
+| @og:description@ | __Optional__ brief description taken from context  |
+|                  | field @og-description@, if set.                    |
++------------------+----------------------------------------------------+
+| @og:image@       | __Optional__ image URL taken from context          |
+|                  | field @og-image@, if set.                          |
++------------------+----------------------------------------------------+
+
+To use, add 'openGraphField' to the template context:
+
+@
+let
+  context = 'defaultContext' <> …
+  postContext = context <> 'openGraphField' "opengraph" context
+@
+
+and update the template:
+
+@
+\<head>
+  \<title>$title$</title>
+  \<link rel="stylesheet" type="text\/css" href="\/css\/default.css" />
+  $if(opengraph)$$opengraph$$endif$
+\</head>
+@
+
+See also "Hakyll.Web.Meta.TwitterCard".
+
+-}
+module Hakyll.Web.Meta.OpenGraph
+  ( openGraphField
+  ) where
+
+import Hakyll
+
+openGraphField :: String -> Context String -> Context String
+openGraphField k ctx = functionField k $ \_args i -> do
+  template <- openGraphTemplate
+  itemBody <$> applyTemplate template ctx i
+
+openGraphTemplate :: Compiler Template
+openGraphTemplate = do
+  makeItem openGraphTemplateString >>= compileTemplateItem
+
+openGraphTemplateString :: String
+openGraphTemplateString =
+  "<meta property=\"og:type\" content=\"article\" />\
+  \<meta property=\"og:url\" content=\"$root$$url$\" />\
+  \<meta property=\"og:title\" content=\"$title$\" />\
+  \$if(og-description)$\
+  \<meta property=\"og:description\" content=\"$og-description$\" />\
+  \$endif$\
+  \$if(og-image)$\
+  \<meta property=\"og:image\" content=\"$og-image$\" />\
+  \$endif$\
+  \"

--- a/lib/Hakyll/Web/Meta/TwitterCard.hs
+++ b/lib/Hakyll/Web/Meta/TwitterCard.hs
@@ -1,0 +1,60 @@
+{- |
+
+Twitter Card metadata, as described at
+<https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started>.
+This feature should be used alongside "Hakyll.Web.Meta.OpenGraph".
+The following properties are supported:
+
++-------------------+----------------------------------------------------+
+| @twitter:card@    | __Hardcoded__ card type = @"summary"@.             |
++-------------------+----------------------------------------------------+
+| @twitter:creator@ | __Optional__ author's Twitter user name.           |
+|                   | Taken from @twitter-creator@ context field, if set.|
++-------------------+----------------------------------------------------+
+| @twitter:site@    | __Optional__ publication's Twitter user name.      |
+|                   | Taken from @twitter-site@ context field, if set.   |
++-------------------+----------------------------------------------------+
+
+To use, add 'openGraphField' and 'twitterCardField' to the template context:
+
+@
+let
+  context = 'defaultContext' <> …
+  postContext =
+    context
+    <> 'openGraphField' "opengraph" context
+    <> 'twitterCardField' "twitter" context
+@
+
+and update the template:
+
+@
+\<head>
+  \<title>$title$\</title>
+  \<link rel="stylesheet" type="text\/css" href="\/css\/default.css" />
+  $if(opengraph)$$opengraph$$endif$
+  $if(twitter)$$twitter$$endif$
+\</head>
+@
+
+-}
+module Hakyll.Web.Meta.TwitterCard
+  ( twitterCardField
+  ) where
+
+import Hakyll
+
+twitterCardField :: String -> Context String -> Context String
+twitterCardField k ctx = functionField k $ \_args i -> do
+  template <- twitterCardTemplate
+  itemBody <$> applyTemplate template ctx i
+
+twitterCardTemplate :: Compiler Template
+twitterCardTemplate = do
+  makeItem twitterCardTemplateString >>= compileTemplateItem
+
+twitterCardTemplateString :: String
+twitterCardTemplateString =
+  "<meta name=\"twitter:card\" content=\"summary\" />\
+  \$if(twitter-creator)$<meta property=\"twitter:creator\" content=\"$twitter-creator$\" />$endif$\
+  \$if(twitter-site)$<meta property=\"twitter:site\" content=\"$twitter-site$\" />$endif$"

--- a/lib/Hakyll/Web/Meta/TwitterCard.hs
+++ b/lib/Hakyll/Web/Meta/TwitterCard.hs
@@ -42,7 +42,10 @@ module Hakyll.Web.Meta.TwitterCard
   ( twitterCardField
   ) where
 
-import Hakyll
+import Hakyll.Core.Compiler
+import Hakyll.Core.Item
+import Hakyll.Web.Template
+import Hakyll.Web.Template.Context
 
 twitterCardField :: String -> Context String -> Context String
 twitterCardField k ctx = functionField k $ \_args i -> do


### PR DESCRIPTION
This PR adds a simple way to add OpenGraph, Twitter Card and JSON-LD metadata
to the HTML for an article.  These standards support rich search results and
better presentation of links when posting on social media, etc.

I believe these features would be appreciated by many users of Hakyll.  And
they introduce no new dependencies (one transitive dependency - *aeson* -
becomes a direct dependency).  Hence I propose inclusion as part of the
*hakyll* package itself.