### PR TITLE
Allow file-embed 0.0.15.0

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -183,7 +183,7 @@ Library
     data-default         >= 0.4      && < 0.8,
     deepseq              >= 1.3      && < 1.5,
     directory            >= 1.2.7.0  && < 1.4,
-    file-embed           >= 0.0.10.1 && < 0.0.15,
+    file-embed           >= 0.0.10.1 && < 0.0.16,
     filepath             >= 1.0      && < 1.5,
     hashable             >= 1.0      && < 2,
     lifted-async         >= 0.10     && < 1,


### PR DESCRIPTION
Tested with `for action in build test ; do cabal $action --enable-tests --constrain 'file-embed == 0.0.15.0' || break ; done`.