### PR TITLE
CI: add GHC 9, bump GHC 8.10 and Stack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,8 @@ jobs:
         ghc:
           - "8.6.5"
           - "8.8.4"
-          - "8.10.4"
+          - "8.10.7"
+          - "9.0.1"
         exclude:
           - os: macOS-latest
             ghc: 8.8.4
@@ -63,8 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: ["2.7.1"]
-        ghc: ["8.8.4"]
+        stack: ["2.7.3"]
+        ghc: ["8.10.7"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,12 @@ jobs:
             ghc: 8.8.4
           - os: windows-latest
             ghc: 8.6.5
+          # Chocolatey only has 8.10.6 at the moment
+          - os: windows-latest
+            ghc: 8.10.7
+        include:
+          - os: windows-latest
+            ghc: 8.10.6
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Normally we exclude older compilers on macOS and Windows, but since
GHC 9 is fairly new still, I chose to keep GHC 8.10 in the matrix for
a while longer.