### PR TITLE
loadAllSnapshots: emit all dependencies at once

### DIFF
--- a/lib/Hakyll/Core/Compiler/Internal.hs
+++ b/lib/Hakyll/Core/Compiler/Internal.hs
@@ -135,7 +135,7 @@ compilerErrorMessages (CompilationNoResult x) = x
 data CompilerResult a
     = CompilerDone a CompilerWrite
     | CompilerSnapshot Snapshot (Compiler a)
-    | CompilerRequire (Identifier, Snapshot) (Compiler a)
+    | CompilerRequire [(Identifier, Snapshot)] (Compiler a)
     | CompilerError (CompilerErrors String)
 
 


### PR DESCRIPTION
Currently, `loadAllSnapshots` loads snapshots one at a time,
emitting a `CompilerRequire` intermediate result for each one.  This
results in additional iterations of `pickAndChase`, with extra
computation to test for dependency cycles each time.

But for `loadAllSnapshots`, we immediately know all the depenencies
to add.  Therefore, update the `CompilerRequire` constructor to have
a list of `(Identifier, Snapshot)` pairs.

Extract snapshot loading to a new `loadSnapshotCollection` helper
function, which operates on a collection of required snapshots:

    loadSnapshotCollection
        :: (Binary a, Typeable a, Traversable t)
        => t (Identifier, Snapshot) -> Compiler (t (Item a))

`t` can be instantiated at `[]` to load multiple snapshots, emitting
a single `CompilerRequire` intermediate result for the whole
collection.  For loading a single snapshot, `t` can be instantiated
at `Identity`.  This commit updates both `loadSnapshot` and
`loadAllSnapshots` to use `loadSnapshotCollection`.

Compared to the preceding commit, this change results in a ~5%
speedup for my site:

```
% hyperfine \
    --prepare './site-4.14.1  clean' './site-4.14.1  build' \
    --prepare './site-mul-req clean' './site-mul-req build'
Benchmark #1: ./site-4.14.1 build
  Time (mean ± σ):      6.744 s ±  0.025 s    [User: 6.452 s, System: 0.284 s]
  Range (min … max):    6.687 s …  6.786 s    10 runs

Benchmark #2: ./site-mul-req build
  Time (mean ± σ):      6.453 s ±  0.079 s    [User: 6.177 s, System: 0.269 s]
  Range (min … max):    6.337 s …  6.579 s    10 runs

Summary
  './site-mul-req build' ran
    1.05 ± 0.01 times faster than './site-4.14.1 build'
```