### PR TITLE
runtime: use Data.Graph.scc to check for dependency cycles

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -173,7 +173,6 @@ Library
 
   Build-Depends:
     aeson                >= 1.0      && < 1.6,
-    array                >= 0.5      && < 1,
     base                 >= 4.8      && < 5,
     binary               >= 0.5      && < 0.10,
     blaze-html           >= 0.5      && < 0.10,


### PR DESCRIPTION
A directed graph is acyclic if and only if all strongly connected
components have at most one vertex.  `Data.Graph` provides the `scc`
function, which uses the Kosaraju's linear-time algorithm to compute
the strongly connected components.

Refactor the runtime cycle detection to use `scc`, a considerable
simplification.  Benchmarking my blog suggests a small performance
increase.

```
% hyperfine \
    --prepare './site-old clean' './site-old build' \
    --prepare './site-scc clean' './site-scc build'
Benchmark #1: ./site-old build
  Time (mean ± σ):      7.054 s ±  0.084 s    [User: 6.767 s, System: 0.256 s]
  Range (min … max):    6.957 s …  7.219 s    10 runs

Benchmark #2: ./site-scc build
  Time (mean ± σ):      7.010 s ±  0.110 s    [User: 6.733 s, System: 0.251 s]
  Range (min … max):    6.816 s …  7.223 s    10 runs

Summary
  './site-scc build' ran
    1.01 ± 0.02 times faster than './site-old build'
```