### PR TITLE
add recompiling `safeCompiler :: IO a -> Compiler a`

### DIFF
--- a/lib/Hakyll/Core/Compiler.hs
+++ b/lib/Hakyll/Core/Compiler.hs
@@ -22,6 +22,7 @@ module Hakyll.Core.Compiler
     , Internal.loadAllSnapshots
 
     , cached
+    , recompilingUnsafeCompiler
     , unsafeCompiler
     , debugCompiler
     , noResult
@@ -185,9 +186,18 @@ cached name compiler = do
 
 
 --------------------------------------------------------------------------------
--- | Run an IO computation without dependencies in a Compiler
+-- | Run an IO computation without dependencies in a Compiler.
+-- You probably want 'recompilingUnsafeCompiler' instead.
 unsafeCompiler :: IO a -> Compiler a
 unsafeCompiler = compilerUnsafeIO
+
+--------------------------------------------------------------------------------
+-- | Run an IO computation in a Compiler.  Unlike 'unsafeCompiler',
+-- this function will cause the item to be recompiled every time.
+recompilingUnsafeCompiler :: IO a -> Compiler a
+recompilingUnsafeCompiler io = Compiler $ \_ -> do
+  a <- io
+  pure $ CompilerDone a mempty { compilerDependencies = [AlwaysOutOfDate] }
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Core/Rules.hs
+++ b/lib/Hakyll/Core/Rules.hs
@@ -29,7 +29,6 @@ module Hakyll.Core.Rules
     , preprocess
     , Dependency (..)
     , rulesExtraDependencies
-    , forceCompile
     ) where
 
 
@@ -222,11 +221,3 @@ rulesExtraDependencies deps rules =
             | (i, c) <- rulesCompilers ruleSet
             ]
         }
-
-
---------------------------------------------------------------------------------
--- | Force the item(s) to always be recompiled, whether or not the
--- dependencies are out of date.  This can be useful if you are using
--- I/O to generate part (or all) of an item.
-forceCompile :: Rules a -> Rules a
-forceCompile = rulesExtraDependencies [AlwaysOutOfDate]


### PR DESCRIPTION
Commit 6885325146aa46adf255c55de0e0345a0f84961e added the
`AlwaysOutOfDate` dependency type, and the `forceRecompile` rules
modifier.  Users can use this to force recompilation of items that
use `unsafeCompiler` to run IO.

But it would be more convenient to have a `Compiler` that runs `IO`
actions and forces recompilation.  Add the `safeCompiler` function
for this purpose.