### PR TITLE
compilerGetMatches: improve performance

### DIFF
--- a/lib/Hakyll/Core/Compiler/Internal.hs
+++ b/lib/Hakyll/Core/Compiler/Internal.hs
@@ -364,7 +364,6 @@ compilerGetMetadata identifier = do
 compilerGetMatches :: Pattern -> Compiler [Identifier]
 compilerGetMatches pattern = do
     universe <- compilerUniverse <$> compilerAsk
-    let matching = filterMatches pattern $ S.toList universe
-        set'     = S.fromList matching
-    compilerTellDependencies [PatternDependency pattern set']
-    return matching
+    let matching = S.filter (matches pattern) universe
+    compilerTellDependencies [PatternDependency pattern matching]
+    pure $ S.toList matching


### PR DESCRIPTION
Use `Data.Set.filter` instead of converting to list, filtering the
list then building a new `Set`.  This results in a ~3% speedup for
my site:

```
% hyperfine \
    --prepare './site-master clean' './site-master build' \
    --prepare './site-set    clean' './site-set    build'
Benchmark #1: ./site-master build
  Time (mean ± σ):      6.855 s ±  0.111 s    [User: 6.567 s, System: 0.261 s]
  Range (min … max):    6.757 s …  7.122 s    10 runs

Benchmark #2: ./site-set    build
  Time (mean ± σ):      6.658 s ±  0.093 s    [User: 6.378 s, System: 0.258 s]
  Range (min … max):    6.488 s …  6.842 s    10 runs

Summary
  './site-set build +RTS -N1' ran
    1.03 ± 0.02 times faster than './site-master build +RTS -N1'
```