### PR TITLE
build: add --dry-run option

### DIFF
--- a/lib/Hakyll/Commands.hs
+++ b/lib/Hakyll/Commands.hs
@@ -48,8 +48,8 @@ import           System.IO.Error            (catchIOError)
 
 --------------------------------------------------------------------------------
 -- | Build the site
-build :: Configuration -> Logger -> Rules a -> IO ExitCode
-build conf logger rules = fst <$> run conf logger rules
+build :: RunMode -> Configuration -> Logger -> Rules a -> IO ExitCode
+build mode conf logger rules = fst <$> run mode conf logger rules
 
 
 --------------------------------------------------------------------------------
@@ -105,7 +105,7 @@ watch conf logger host port runServer rules = do
     server'
   where
     update = do
-        (_, ruleSet) <- run conf logger rules
+        (_, ruleSet) <- run RunModeNormal conf logger rules
         return $ rulesPattern ruleSet
     loop = threadDelay 100000 >> loop
     server' = if runServer then server conf logger host port else loop
@@ -117,7 +117,7 @@ watch _ _ _ _ _ _ = watchServerDisabled
 -- | Rebuild the site
 rebuild :: Configuration -> Logger -> Rules a -> IO ExitCode
 rebuild conf logger rules =
-    clean conf logger >> build conf logger rules
+    clean conf logger *> build RunModeNormal conf logger rules
 
 --------------------------------------------------------------------------------
 -- | Start a server

--- a/lib/Hakyll/Main.hs
+++ b/lib/Hakyll/Main.hs
@@ -39,6 +39,7 @@ import qualified Hakyll.Commands           as Commands
 import qualified Hakyll.Core.Configuration as Config
 import qualified Hakyll.Core.Logger        as Logger
 import           Hakyll.Core.Rules
+import           Hakyll.Core.Runtime
 
 
 --------------------------------------------------------------------------------
@@ -105,7 +106,7 @@ invokeCommands :: Command -> Config.Configuration ->
                   Check.Check -> Logger.Logger -> Rules a -> IO ExitCode
 invokeCommands args conf check logger rules =
     case args of
-        Build          -> Commands.build conf logger rules
+        Build   mode   -> Commands.build mode conf logger rules
         Check   _      -> Commands.check conf logger check
         Clean          -> Commands.clean conf logger >> ok
         Deploy         -> Commands.deploy conf
@@ -125,7 +126,7 @@ data Options = Options {verbosity :: Bool, optCommand :: Command}
 
 -- | The command to run.
 data Command
-    = Build
+    = Build RunMode
     -- ^ Generate the site.
     | Check   {internal_links :: Bool}
     -- ^ Validate the site output.
@@ -161,7 +162,7 @@ commandParser conf = OA.subparser $ foldr ((<>) . produceCommand) mempty command
 
     commands =
         [ ( "build"
-          , pure Build
+          , pure Build <*> OA.flag RunModeNormal RunModePrintOutOfDate (OA.long "dry-run" <> OA.help "Don't build, only print out-of-date items")
           , OA.fullDesc <> OA.progDesc "Generate the site"
           )
         , ( "check"

--- a/tests/Hakyll/Core/Runtime/Tests.hs
+++ b/tests/Hakyll/Core/Runtime/Tests.hs
@@ -30,7 +30,7 @@ tests = testGroup "Hakyll.Core.Runtime.Tests" $
 case01 :: Assertion
 case01 = do
     logger <- Logger.new Logger.Error
-    _      <- run testConfiguration logger $ do
+    _      <- run RunModeNormal testConfiguration logger $ do
         match "images/*" $ do
             route idRoute
             compile copyFileCompiler
@@ -81,7 +81,7 @@ case01 = do
 case02 :: Assertion
 case02 = do
     logger <- Logger.new Logger.Error
-    _      <- run testConfiguration logger $ do
+    _      <- run RunModeNormal testConfiguration logger $ do
         match "images/favicon.ico" $ do
             route   $ gsubRoute "images/" (const "")
             compile $ makeItem ("Test" :: String)
@@ -102,7 +102,7 @@ case02 = do
 case03 :: Assertion
 case03 = do
     logger  <- Logger.new Logger.Error
-    (ec, _) <- run testConfiguration logger $ do
+    (ec, _) <- run RunModeNormal testConfiguration logger $ do
 
         create ["partial.html.out1"] $ do
             route idRoute

--- a/tests/Hakyll/Web/Pandoc/Biblio/Tests.hs
+++ b/tests/Hakyll/Web/Pandoc/Biblio/Tests.hs
@@ -41,7 +41,7 @@ goldenTest01 =
             -- Code lifted from https://github.com/jaspervdj/hakyll-citeproc-example.
             logger <- Logger.new Logger.Error
             let config = testConfiguration { providerDirectory = goldenTestsDataDir }
-            _ <- run config logger $ do
+            _ <- run RunModeNormal config logger $ do
                 let myPandocBiblioCompiler = do
                         csl <- load "chicago.csl"
                         bib <- load "refs.bib"


### PR DESCRIPTION
Add a --dry-run option to the build command.  In this mode, build
prints the list of items that need to be (re)compiled.

This mode is also useful for benchmarking the initialisation phase.