### PR TITLE
Add support for  jupyter notebooks

### DIFF
--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -58,6 +58,7 @@ readPandocWith ropt item =
     reader ro t = case t of
         DocBook            -> readDocBook ro
         Html               -> readHtml ro
+        Jupyter            -> readIpynb ro
         LaTeX              -> readLaTeX ro
         LiterateHaskell t' -> reader (addExt ro Ext_literate_haskell) t'
         Markdown           -> readMarkdown ro

--- a/lib/Hakyll/Web/Pandoc/Biblio.hs
+++ b/lib/Hakyll/Web/Pandoc/Biblio.hs
@@ -19,6 +19,7 @@ module Hakyll.Web.Pandoc.Biblio
     , Biblio (..)
     , biblioCompiler
     , readPandocBiblio
+    , processPandocBiblio
     , pandocBiblioCompiler
     ) where
 
@@ -84,6 +85,14 @@ readPandocBiblio :: ReaderOptions
                  -> (Item String)
                  -> Compiler (Item Pandoc)
 readPandocBiblio ropt csl biblio item = do
+  pandoc <- readPandocWith ropt item
+  processPandocBiblio csl biblio pandoc
+
+processPandocBiblio :: Item CSL
+                    -> Item Biblio
+                    -> (Item Pandoc)
+                    -> Compiler (Item Pandoc)
+processPandocBiblio csl biblio item = do
     -- It's not straightforward to use the Pandoc API as of 2.11 to deal with
     -- citations, since it doesn't export many things in 'Text.Pandoc.Citeproc'.
     -- The 'citeproc' package is also hard to use.
@@ -93,10 +102,8 @@ readPandocBiblio ropt csl biblio item = do
     --
     -- So we load the CSL and Biblio files and pass them to Pandoc using the
     -- ersatz filesystem.
-    Pandoc.Pandoc (Pandoc.Meta meta) blocks <- itemBody <$>
-        readPandocWith ropt item
-
-    let cslFile = Pandoc.FileInfo zeroTime . unCSL $ itemBody csl
+    let Pandoc.Pandoc (Pandoc.Meta meta) blocks = itemBody item
+        cslFile = Pandoc.FileInfo zeroTime . unCSL $ itemBody csl
         bibFile = Pandoc.FileInfo zeroTime . unBiblio $ itemBody biblio
         addBiblioFiles = \st -> st
             { Pandoc.stFiles =

--- a/lib/Hakyll/Web/Pandoc/FileType.hs
+++ b/lib/Hakyll/Web/Pandoc/FileType.hs
@@ -24,6 +24,7 @@ data FileType
     | Css
     | DocBook
     | Html
+    | Jupyter
     | LaTeX
     | LiterateHaskell FileType
     | Markdown
@@ -42,6 +43,7 @@ fileType = uncurry fileType' . splitExtension
   where
     fileType' _ ".css"       = Css
     fileType' _ ".dbk"       = DocBook
+    fileType' _ ".ipynb"     = Jupyter
     fileType' _ ".htm"       = Html
     fileType' _ ".html"      = Html
     fileType' f ".lhs"       = LiterateHaskell $ case fileType f of

--- a/tests/Hakyll/Web/Pandoc/FileType/Tests.hs
+++ b/tests/Hakyll/Web/Pandoc/FileType/Tests.hs
@@ -19,7 +19,8 @@ import           TestSuite.Util
 tests :: TestTree
 tests = testGroup "Hakyll.Web.Pandoc.FileType.Tests" $
     fromAssertions "fileType"
-        [ Markdown                 @=? fileType "index.md"
+        [ Jupyter                  @=? fileType "index.ipynb"
+        , Markdown                 @=? fileType "index.md"
         , Rst                      @=? fileType "about/foo.rst"
         , LiterateHaskell Markdown @=? fileType "posts/bananas.lhs"
         , LiterateHaskell LaTeX    @=? fileType "posts/bananas.tex.lhs"


### PR DESCRIPTION
Pandoc can now handle Jupyter notebooks. Add support for this format to Hakyll.