### PR TITLE
Add Jekyll Style URLs with Hakyll to tutorials

### DIFF
--- a/web/tutorials/external-jekyll-style-urls-with-hakyll.markdown
+++ b/web/tutorials/external-jekyll-style-urls-with-hakyll.markdown
@@ -1,0 +1,6 @@
+---
+title: Jekyll Style URLs with Hakyll
+author: Andreas Herrmann
+url: 'http://aherrmann.github.io/programming/2016/01/31/jekyll-style-urls-with-hakyll/index.html'
+type: external
+---


### PR DESCRIPTION
This repo and the [companion repo](https://github.com/aherrmann/jekyll_style_urls_with_hakyll_examples/blob/master/site.hs) (which doesn't seem to be linked in the post for some reason) were very helpful and saved me a whole bunch of trouble in porting my blog from Jekyll to Hakyll without breaking too many deeplinks. I figured it'd be a good inclusion here.