### PR TITLE
Remove `array` dependency

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -173,7 +173,6 @@ Library
 
   Build-Depends:
     aeson                >= 1.0      && < 1.6,
-    array                >= 0.5      && < 1,
     base                 >= 4.8      && < 5,
     binary               >= 0.5      && < 0.10,
     blaze-html           >= 0.5      && < 0.10,


### PR DESCRIPTION
The `array` dependency was introduced in #844 to perform topological sorting of requirements. This functionality was improved in #880 which means that the `array` dependency is superfluous. 