### PR TITLE
Hakyll.Web.Html: fix processing of `srcset` attribute

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -284,6 +284,7 @@ Test-suite hakyll-tests
     bytestring           >= 0.9      && < 0.11,
     containers           >= 0.3      && < 0.7,
     filepath             >= 1.0      && < 1.5,
+    tagsoup              >= 0.13.1   && < 0.15,
     text                 >= 0.11     && < 1.3,
     unordered-containers >= 0.2      && < 0.3,
     yaml                 >= 0.8.11   && < 0.12

--- a/tests/Hakyll/Web/Html/RelativizeUrls/Tests.hs
+++ b/tests/Hakyll/Web/Html/RelativizeUrls/Tests.hs
@@ -35,4 +35,6 @@ tests = testGroup "Hakyll.Web.Html.RelativizeUrls.Tests" $
         , "<script src=\"//ajax.googleapis.com/jquery.min.js\"></script>" @=?
             relativizeUrlsWith "../.."
                 "<script src=\"//ajax.googleapis.com/jquery.min.js\"></script>"
+        , "<img srcset=\"./image.png 200w, ./image2.png 400w\" />"  @=?
+            relativizeUrlsWith "." "<img srcset=\"/image.png 200w, /image2.png 400w\" />"
         ]


### PR DESCRIPTION
We used to assume that `srcset` is just like `src`, and contains only
one URL. As the name of the attribute might suggest, this assumption is
wrong.

The attribute's value has a somewhat-complex grammar, with optional
fields and different separators, so I implemented a Parsec parser for
(the most of) it. The parser expects URLs to be a contiguous string of
anything but space or comma (`srcset`'s separators); I hope it will be
sufficient.

This also adds tests for the affected functions, and documentation for
`getUrls`.

Fixes #889.