### PR TITLE
Allow bytestring 0.11.*

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -179,7 +179,7 @@ Library
     binary               >= 0.5      && < 0.10,
     blaze-html           >= 0.5      && < 0.10,
     blaze-markup         >= 0.5.1    && < 0.9,
-    bytestring           >= 0.9      && < 0.11,
+    bytestring           >= 0.9      && < 0.12,
     containers           >= 0.3      && < 0.7,
     data-default         >= 0.4      && < 0.8,
     deepseq              >= 1.3      && < 1.5,
@@ -282,7 +282,7 @@ Test-suite hakyll-tests
     tasty-quickcheck           >= 0.8  && < 0.11,
     -- Copy pasted from hakyll dependencies:
     base                 >= 4.8      && < 5,
-    bytestring           >= 0.9      && < 0.11,
+    bytestring           >= 0.9      && < 0.12,
     containers           >= 0.3      && < 0.7,
     filepath             >= 1.0      && < 1.5,
     tagsoup              >= 0.13.1   && < 0.15,


### PR DESCRIPTION
`cabal build --enable-tests --constrain 'bytestring == 0.11.1.0' && cabal test --constrain 'bytestring == 0.11.1.0' ` finished fine.