### PR TITLE
Allow pandoc 2.15

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -243,7 +243,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.15
+      pandoc >= 2.11 && < 2.16
     Cpp-options:
       -DUSE_PANDOC
 
@@ -340,4 +340,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.11  && < 2.15
+    pandoc    >= 2.11  && < 2.16


### PR DESCRIPTION
`for action in build test ; do cabal $action --enable-tests --constrain 'pandoc == 2.15' || break ; done` passed.

Looks like we'll have to make a new release in order to support Aeson 2, so I won't make a Hackage revision for this PR. I hope I'll make the Aeson changes in the next few days (but I'll be happy if someone beats me to it :)