### PR TITLE
Allow pandoc 2.16

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -246,7 +246,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.16
+      pandoc >= 2.11 && < 2.17
     Cpp-options:
       -DUSE_PANDOC
 
@@ -344,4 +344,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.11  && < 2.16
+    pandoc    >= 2.11  && < 2.17


### PR DESCRIPTION
`for action in build test ; do cabal $action --enable-tests --constrain 'pandoc == 2.16' || break ; done` passed.

Once this is merged, I will also make a Hackage revision.