### PR TITLE
Allow pandoc 2.17

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -246,7 +246,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.17
+      pandoc >= 2.11 && < 2.18
     Cpp-options:
       -DUSE_PANDOC
 
@@ -344,4 +344,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.11  && < 2.17
+    pandoc    >= 2.11  && < 2.18

--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -190,4 +190,10 @@ defaultHakyllWriterOptions = def
     , -- We want to have hightlighting by default, to be compatible with earlier
       -- Hakyll releases
       writerHighlightStyle = Just pygments
+    , -- Do not word-wrap produced HTML, and do not undo any word-wrapping
+      -- that's already present in the markup. This is how Pandoc operated
+      -- prior to 2.17, but the behaviour was changed for consistency with
+      -- other Pandoc writers. We retain the old behaviour because it spares us
+      -- the trouble of updating our golden tests.
+      writerWrapText = WrapPreserve
     }

--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -109,14 +109,14 @@ renderPandocWith ropt wopt item =
 --------------------------------------------------------------------------------
 -- | An extension of `renderPandocWith`, which allows you to specify a custom
 -- Pandoc transformation on the input `Item`.
--- Useful if you want to do your own transformations before running 
+-- Useful if you want to do your own transformations before running
 -- custom Pandoc transformations, e.g. using a `funcField` to transform raw content.
 renderPandocWithTransform :: ReaderOptions -> WriterOptions
                     -> (Pandoc -> Pandoc)
                     -> Item String
                     -> Compiler (Item String)
-renderPandocWithTransform ropt wopt f = 
-    renderPandocWithTransformM ropt wopt (return . f) 
+renderPandocWithTransform ropt wopt f =
+    renderPandocWithTransformM ropt wopt (return . f)
 
 
 --------------------------------------------------------------------------------
@@ -128,8 +128,8 @@ renderPandocWithTransformM :: ReaderOptions -> WriterOptions
                     -> (Pandoc -> Compiler Pandoc)
                     -> Item String
                     -> Compiler (Item String)
-renderPandocWithTransformM ropt wopt f i = 
-    writePandocWith wopt <$> (traverse f =<< readPandocWith ropt i) 
+renderPandocWithTransformM ropt wopt f i =
+    writePandocWith wopt <$> (traverse f =<< readPandocWith ropt i)
 
 
 --------------------------------------------------------------------------------
@@ -166,7 +166,7 @@ pandocCompilerWithTransform ropt wopt f =
 pandocCompilerWithTransformM :: ReaderOptions -> WriterOptions
                     -> (Pandoc -> Compiler Pandoc)
                     -> Compiler (Item String)
-pandocCompilerWithTransformM ropt wopt f = 
+pandocCompilerWithTransformM ropt wopt f =
     getResourceBody >>= renderPandocWithTransformM ropt wopt f
 
 


### PR DESCRIPTION
Both of these commands passed:

```
$ cabal build --enable-tests --constrain 'pandoc == 2.16.2' && cabal test --constrain 'pandoc == 2.16.2' 
$ cabal build --enable-tests --constrain 'pandoc == 2.17.0.1' && cabal test --constrain 'pandoc == 2.17.0.1' 
```

I'll make a new release right after this is merged.