### PR TITLE
web: Fix link to part one of Robert Pearce's tutorial

### DIFF
--- a/web/tutorials/robertwpearce-01-setup-and-initial-customization.html
+++ b/web/tutorials/robertwpearce-01-setup-and-initial-customization.html
@@ -1,5 +1,5 @@
 ---
 title: 'Pt. 1: Setup & Initial Customization'
-url: 'https://robertwpearce.com/hakyll-pt-1-setup-and-initial-customization.html'
+url: 'https://robertwpearce.com/hakyll-pt-1-setup-initial-customization.html'
 type: robertwpearce
 ---


### PR DESCRIPTION
The URL must have changed at some point, as I can even find some dead links on that person's website.  I rebuid the site with the `buildWebsite` flag and then checked things via `stack exec hakyll-website watch` and it looked fine to me—hopefully that was correct