### PR TITLE
Add importField in Hakyll.Web.Template.Context

### DIFF
--- a/lib/Hakyll/Core/Provider/Metadata.hs
+++ b/lib/Hakyll/Core/Provider/Metadata.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RecordWildCards #-}
 module Hakyll.Core.Provider.Metadata
     ( loadMetadata
+    , loadMetadataFile
     , parsePage
 
     , MetadataException (..)

--- a/lib/Hakyll/Web/Template/Context.hs
+++ b/lib/Hakyll/Web/Template/Context.hs
@@ -68,11 +68,12 @@ import           Hakyll.Core.Identifier
 import           Hakyll.Core.Item
 import           Hakyll.Core.Metadata
 import           Hakyll.Core.Provider
+import           Hakyll.Core.Provider.Metadata (loadMetadataFile)
 import           Hakyll.Core.Util.String       (needlePrefix, splitAll)
 import           Hakyll.Web.Html
 import           Prelude                       hiding (id)
 import           System.FilePath               (dropExtension, splitDirectories,
-                                                takeBaseName)
+                                                takeBaseName, takeDirectory, (</>))
 
 
 --------------------------------------------------------------------------------
@@ -454,6 +455,23 @@ teaserFieldWithSeparator separator key snapshot = field key $ \item -> do
             "Hakyll.Web.Template.Context: no teaser defined for " ++
             show (itemIdentifier item)
         Just t -> return t
+
+
+--------------------------------------------------------------------------------
+-- | If an "import" field can be found in the metadata which contains
+-- a file path, parse the file as metadata and map any field to it.
+importField :: Context a
+importField = Context $ \k _ i -> do
+    let id = itemIdentifier i
+    metadata <- getMetadata id 
+    case lookupString "import" metadata of
+      Just fileName -> do
+        let fileDir = takeDirectory $ toFilePath id
+            fp      = fileDir </> fileName
+            empty'  =  noResult $ "No '" ++ k ++ "' field in imported metadata of " ++ show (fromFilePath fp)
+        metadata' <- unsafeCompiler $ loadMetadataFile fp
+        maybe empty' (return . StringField) (lookupString k metadata')
+      Nothing -> noResult $ "No 'import' field found in " ++ show id
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
As mentioned in #924 I've implemented a field for importing another file in the metadata.
Unfortunately, I haven't found the way to track the dependencies of the imported file (the usage of `unsafeCompiler` is probably non-ideal), which means rebuilds do not check if the imported files are modified.
Can anyone share some thoughts on how to track the dependencies?