### PR TITLE
Allow pandoc 2.18

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -246,7 +246,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.18
+      pandoc >= 2.11 && < 2.19
     Cpp-options:
       -DUSE_PANDOC
 
@@ -344,4 +344,4 @@ Executable hakyll-website
     base      >= 4     && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.5,
-    pandoc    >= 2.11  && < 2.18
+    pandoc    >= 2.11  && < 2.19


### PR DESCRIPTION
This passed:

```
$ for action in build test ; do cabal $action --enable-tests --constrain 'pandoc == 2.18' || break ; done
```