### PR TITLE
Allow text 2.0

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -203,7 +203,7 @@ Library
     scientific           >= 0.3.4    && < 0.4,
     tagsoup              >= 0.13.1   && < 0.15,
     template-haskell     >= 2.14     && < 2.19,
-    text                 >= 0.11     && < 1.3,
+    text                 >= 0.11     && < 1.3 || >= 2.0 && < 2.1,
     time                 >= 1.8      && < 1.12,
     time-locale-compat   >= 0.1      && < 0.2,
     unordered-containers >= 0.2      && < 0.3,
@@ -290,7 +290,7 @@ Test-suite hakyll-tests
     containers           >= 0.3      && < 0.7,
     filepath             >= 1.0      && < 1.5,
     tagsoup              >= 0.13.1   && < 0.15,
-    text                 >= 0.11     && < 1.3,
+    text                 >= 0.11     && < 1.3 || >= 2.0 && < 2.1,
     unordered-containers >= 0.2      && < 0.3,
     yaml                 >= 0.8.11   && < 0.12
 


### PR DESCRIPTION
`for action in build test ; do cabal $action --enable-tests --constrain 'text == 2.0' || break ; done` passed.