### PR TITLE
Short helper for new users added to README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,3 +13,13 @@ You can install this library using cabal:
 Or using stack:
 
     stack install hakyll
+
+When using _hakyll_ for a single website, or for the sake of trying out _hakyll_, users might find it more convenient to install it in a local repository (i.e. the repository from which they will build and deploy the website). In that case simply create a template directory using your favorite project manager and run the above command from it:
+
+    mkdir <project's directory>
+    cd <project's directory>
+    cabal init
+    
+Or for stack users replace the last command with:
+
+    stack init

--- a/README.markdown
+++ b/README.markdown
@@ -6,20 +6,23 @@ Hakyll is a static site generator library in Haskell. More information
 (including a tutorial) can be found on
 [the hakyll homepage](http://jaspervdj.be/hakyll).
 
-You can install this library using cabal:
+To install this library, first create a new directory and under it:
 
-    cabal install hakyll
-
-Or using stack:
-
-    stack install hakyll
-
-When using _hakyll_ for a single website, or for the sake of trying out _hakyll_, users might find it more convenient to install it in a local repository (i.e. the repository from which they will build and deploy the website). In that case simply create a template directory using your favorite project manager and run the above command from it:
-
-    mkdir <project's directory>
-    cd <project's directory>
     cabal init
+
+And then:
     
-Or for stack users replace the last command with:
+    <directory name>.cabal
+    ----------------------
+    build-depends: base ^>=4.15.1.0, hakyll
+
+Or for `stack` users:
 
     stack init
+
+And then:
+
+    package.yaml
+    ------------
+    dependencies:
+     - hakyll


### PR DESCRIPTION
The idea is just to provide a simple way for new users who don't want to fix the `build plan failed` error that is likely to occur if they simply run `stack install` from the global context.