### PR TITLE
Allow aeson 2.1.0.0

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -177,7 +177,7 @@ Library
     Paths_hakyll
 
   Build-Depends:
-    aeson                >= 1.0      && < 1.6 || >= 2.0 && < 2.1,
+    aeson                >= 1.0      && < 1.6 || >= 2.0 && < 2.2,
     base                 >= 4.8      && < 5,
     binary               >= 0.5      && < 0.10,
     blaze-html           >= 0.5      && < 0.10,
@@ -284,7 +284,7 @@ Test-suite hakyll-tests
     tasty-hunit                >= 0.9  && < 0.11,
     tasty-quickcheck           >= 0.8  && < 0.11,
     -- Copy pasted from hakyll dependencies:
-    aeson                >= 1.0      && < 1.6 || >= 2.0 && < 2.1,
+    aeson                >= 1.0      && < 1.6 || >= 2.0 && < 2.2,
     base                 >= 4.8      && < 5,
     bytestring           >= 0.9      && < 0.12,
     containers           >= 0.3      && < 0.7,


### PR DESCRIPTION
`for action in build test ; do cabal $action --enable-tests --constrain 'aeson == 2.1.0.0' || break ; done` passed.