### PR TITLE
Allow resourcet 1.3

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -199,7 +199,7 @@ Library
     process              >= 1.6      && < 1.7,
     random               >= 1.0      && < 1.3,
     regex-tdfa           >= 1.1      && < 1.4,
-    resourcet            >= 1.1      && < 1.3,
+    resourcet            >= 1.1      && < 1.4,
     scientific           >= 0.3.4    && < 0.4,
     tagsoup              >= 0.13.1   && < 0.15,
     template-haskell     >= 2.14     && < 2.19,


### PR DESCRIPTION
This passed: `for action in build test ; do cabal $action --enable-tests --constrain 'resourcet == 1.3.0' || break ; done`.