### PR TITLE
Allow template-haskell 2.20 (GHC 9.4.3)

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -202,7 +202,7 @@ Library
     resourcet            >= 1.1      && < 1.4,
     scientific           >= 0.3.4    && < 0.4,
     tagsoup              >= 0.13.1   && < 0.15,
-    template-haskell     >= 2.14     && < 2.19,
+    template-haskell     >= 2.14     && < 2.20,
     text                 >= 0.11     && < 1.3 || >= 2.0 && < 2.1,
     time                 >= 1.8      && < 1.12,
     time-locale-compat   >= 0.1      && < 0.2,


### PR DESCRIPTION
Tested locally with GHC 9.4.3 by running `for action in build test ; do cabal $action --enable-tests || break ; done`