### PR TITLE
Remove scr.stunts.hu from examples

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -58,8 +58,6 @@ directly with the default Hakyll site.
   [source](https://github.com/xinitrc/xinitrc.de)
 - <http://nickcharlton.net/>,
   [source](https://github.com/nickcharlton/nickcharlton.net)
-- <http://scr.stunts.hu/>,
-  [literate source](http://scr.stunts.hu/hakyll.html)
 - <http://www.eanalytica.com/>,
   [literate source](http://www.eanalytica.com/site/)
 - <http://cse.iitk.ac.in/users/ppk>,


### PR DESCRIPTION
I'm currently doing a partial rewrite of scr.stunts.hu, which makes it difficult to keep the literate source file that was linked from here updated. If I ever get to make the site repository public, I'll bring it back here.