### PR TITLE
Allow mtl 2.3

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -194,7 +194,7 @@ Library
     hashable             >= 1.0      && < 2,
     lifted-async         >= 0.10     && < 1,
     lrucache             >= 1.1.1    && < 1.3,
-    mtl                  >= 1        && < 2.3,
+    mtl                  >= 1        && < 2.4,
     network-uri          >= 2.6      && < 2.7,
     optparse-applicative >= 0.12     && < 0.18,
     parsec               >= 3.0      && < 3.2,

--- a/lib/Hakyll/Web/Html.hs
+++ b/lib/Hakyll/Web/Html.hs
@@ -24,7 +24,8 @@ module Hakyll.Web.Html
 
 
 --------------------------------------------------------------------------------
-import           Control.Monad.Identity          (void, Identity(runIdentity))
+import           Control.Monad                   (void)
+import           Control.Monad.Identity          (Identity(runIdentity))
 import           Data.Char                       (digitToInt, intToDigit,
                                                   isDigit, toLower)
 import           Data.Either                     (fromRight)


### PR DESCRIPTION
This passes:

```
$ for action in build test ; do cabal $action --enable-tests --constrain 'mtl == 2.3.1' || break ; done
```