### PR TITLE
lib/Hakyll/Check.hs: support link-checking in *.xhtml files.

### DIFF
--- a/lib/Hakyll/Check.hs
+++ b/lib/Hakyll/Check.hs
@@ -129,7 +129,7 @@ checkDestination = do
     let htmls =
             [ destinationDirectory config </> file
             | file <- files
-            , takeExtension file == ".html"
+            , takeExtension file `elem` [".html", ".xhtml"]
             ]
 
     forM_ htmls checkFile


### PR DESCRIPTION
The Hakyll "check" command is used to validate links in your site's output, but at the moment it only checks ".html" files. There is also an "xhtml" extension associated with the `application/xhtml+xml` MIME type that more or less contains HTML.

It's important for authors to use a different extension on xhtml+xml files because browsers interpret them differently (they use a faster but stricter parser). Thus simply renaming those files to "html" is not recommended. Instead this commit teaches Hakyll to check "xhtml" files as well.

A more thorough change would allow the user to specify what extensions to consider as "html" -- for example, "htm" and "xhtm" are both common. I however see little need for the complexity, since no one else has hit the issue in so many years. This commit therefore makes the smallest change possible and hard-codes "xhtml" as an additional extension to be checked.

Notably, I have not added "index.xhtml" as a default document in `checkFileExists`, because developing locally (file://) I'm forced to avoid such things in the first place.