### PR TITLE
fix: Twitter Card use `name` instead `property`

### DIFF
--- a/lib/Hakyll/Web/Meta/TwitterCard.hs
+++ b/lib/Hakyll/Web/Meta/TwitterCard.hs
@@ -59,5 +59,5 @@ twitterCardTemplate = do
 twitterCardTemplateString :: String
 twitterCardTemplateString =
   "<meta name=\"twitter:card\" content=\"summary\" />\
-  \$if(twitter-creator)$<meta property=\"twitter:creator\" content=\"$twitter-creator$\" />$endif$\
-  \$if(twitter-site)$<meta property=\"twitter:site\" content=\"$twitter-site$\" />$endif$"
+  \$if(twitter-creator)$<meta name=\"twitter:creator\" content=\"$twitter-creator$\" />$endif$\
+  \$if(twitter-site)$<meta name=\"twitter:site\" content=\"$twitter-site$\" />$endif$"


### PR DESCRIPTION
> Twitter’s parser will fall back to using property and content, so there is no need to modify existing Open Graph protocol markup if it already exists.
>
> [Getting started with Cards | Docs | Twitter Developer Platform](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started)

It may be usable for now since it is fallback, but it is better to output the correct one just in case.