### PR TITLE
Allow configuration of files to be checked for links.

### DIFF
--- a/lib/Hakyll/Check.hs
+++ b/lib/Hakyll/Check.hs
@@ -23,8 +23,7 @@ import           Network.URI                  (unEscapeString)
 import           System.Directory             (doesDirectoryExist,
                                                doesFileExist)
 import           System.Exit                  (ExitCode (..))
-import           System.FilePath              (takeDirectory, takeExtension,
-                                               (</>))
+import           System.FilePath              (takeDirectory, (</>))
 import qualified Text.HTML.TagSoup            as TS
 
 
@@ -129,7 +128,7 @@ checkDestination = do
     let htmls =
             [ destinationDirectory config </> file
             | file <- files
-            , takeExtension file == ".html"
+            , checkHtmlFile config file
             ]
 
     forM_ htmls checkFile

--- a/lib/Hakyll/Core/Configuration.hs
+++ b/lib/Hakyll/Core/Configuration.hs
@@ -111,7 +111,7 @@ defaultConfiguration = Configuration
     , tmpDirectory         = "_cache/tmp"
     , providerDirectory    = "."
     , ignoreFile           = ignoreFile'
-    , checkHtmlFile        = (==) ".html" . takeExtension
+    , checkHtmlFile        = flip elem [".html", ".xhtml"] . takeExtension
     , watchIgnore          = const False
     , deployCommand        = "echo 'No deploy command specified' && exit 1"
     , deploySite           = system . deployCommand

--- a/lib/Hakyll/Core/Configuration.hs
+++ b/lib/Hakyll/Core/Configuration.hs
@@ -14,7 +14,8 @@ import           Data.List        (isPrefixOf, isSuffixOf)
 import qualified Network.Wai.Application.Static as Static
 import           System.Directory (canonicalizePath)
 import           System.Exit      (ExitCode)
-import           System.FilePath  (isAbsolute, normalise, takeFileName, makeRelative)
+import           System.FilePath  (isAbsolute, makeRelative, normalise,
+                                   takeExtension, takeFileName)
 import           System.IO.Error  (catchIOError)
 import           System.Process   (system)
 
@@ -47,6 +48,10 @@ data Configuration = Configuration
       -- want to use the test, you should use 'shouldIgnoreFile'.
       --
       ignoreFile           :: FilePath -> Bool
+    , -- | Function to determine HTML files whose links are to be checked.
+      --
+      -- In 'defaultConfiguration', files with the @.html@ extension are checked.
+      checkHtmlFile        :: FilePath -> Bool
     , -- | Function to determine files and directories that should not trigger
       -- a rebuild when touched in watch mode.
       --
@@ -88,9 +93,9 @@ data Configuration = Configuration
       -- One can also override the port as a command line argument:
       -- ./site preview -p 1234
       previewPort          :: Int
-      -- | Override other settings used by the preview server. Default is
+    , -- | Override other settings used by the preview server. Default is
       -- 'Static.defaultFileServerSettings'.
-    , previewSettings      :: FilePath -> Static.StaticSettings
+      previewSettings      :: FilePath -> Static.StaticSettings
     }
 
 --------------------------------------------------------------------------------
@@ -106,6 +111,7 @@ defaultConfiguration = Configuration
     , tmpDirectory         = "_cache/tmp"
     , providerDirectory    = "."
     , ignoreFile           = ignoreFile'
+    , checkHtmlFile        = (==) ".html" . takeExtension
     , watchIgnore          = const False
     , deployCommand        = "echo 'No deploy command specified' && exit 1"
     , deploySite           = system . deployCommand


### PR DESCRIPTION
This adds a configuration option to customize which files are determined to be HTML files to check links for with `site check`.

This should help resolve https://github.com/jaspervdj/hakyll/issues/742.  While it does not make Hakyll check links for all HTML files regardless of extension, it does make it possible to configure Hakyll to do so.