### PR TITLE
Add JSON Feed support

### DIFF
--- a/data/templates/feed-item.json
+++ b/data/templates/feed-item.json
@@ -1,7 +1,7 @@
 {
     "id": "$root$$url$",
     "url": "$root$$url$",
-    "content_html": "$descriptionJson$",
+    "content_html": "$description$",
     "date_published": "$published$",
     "date_modified": "$updated$"
 }

--- a/data/templates/feed-item.json
+++ b/data/templates/feed-item.json
@@ -1,7 +1,7 @@
 {
     "id": "$root$$url$",
     "url": "$root$$url$",
-    "content_html": $descriptionJson$,
+    "content_html": "$descriptionJson$",
     "date_published": "$published$",
     "date_modified": "$updated$"
 }

--- a/data/templates/feed-item.json
+++ b/data/templates/feed-item.json
@@ -2,6 +2,7 @@
     "id": "$root$$url$",
     "url": "$root$$url$",
     "content_html": "$description$",
+    "title": "$title$",
     "date_published": "$published$",
     "date_modified": "$updated$"
 }

--- a/data/templates/feed-item.json
+++ b/data/templates/feed-item.json
@@ -1,0 +1,7 @@
+{
+    "id": "$root$$url$",
+    "url": "$root$$url$",
+    "content_html": $descriptionJson$,
+    "date_published": "$published$",
+    "date_modified": "$updated$"
+}

--- a/data/templates/feed.json
+++ b/data/templates/feed.json
@@ -1,0 +1,14 @@
+{
+    "version": "https://www.jsonfeed.org/version/1.1",
+    "title": "$title$",
+    "home_page_url": "$root$",
+    "feed_url": "$root$$url$",
+    $if(authorName)$
+    "authors": [
+        {
+            "name": "$authorName$"
+        }
+    ],
+    $endif$
+    "items": [ $body$ ]
+}

--- a/data/templates/feed.json
+++ b/data/templates/feed.json
@@ -7,6 +7,9 @@
     "authors": [
         {
             "name": "$authorName$"
+            $if(authorEmail)$
+            , "url": "mailto:$authorEmail$"
+            $endif$
         }
     ],
     $endif$

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -92,6 +92,8 @@ Extra-source-files:
   data/templates/atom.xml
   data/templates/rss-item.xml
   data/templates/rss.xml
+  data/templates/feed.json
+  data/templates/feed-item.json
 
 Source-Repository head
   Type:     git

--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -40,10 +40,10 @@ import           Hakyll.Web.Template.List
 
 
 --------------------------------------------------------------------------------
+import           Data.Char                   (ord)
 import           Data.FileEmbed              (makeRelativeToProject)
+import           Numeric                     (showHex)
 import           System.FilePath             ((</>))
-import Data.Char (ord)
-import Numeric (showHex)
 
 
 --------------------------------------------------------------------------------
@@ -113,10 +113,10 @@ renderFeed :: FeedType                -- ^ Feed type
 renderFeed feedType feedTpl itemTpl config itemContext items = do
     protectedItems <-
       case feedType of
-        XmlFeed -> mapM (applyFilter protectCDATA) items
+        XmlFeed  -> mapM (applyFilter protectCDATA) items
         JsonFeed -> pure items
     let itemDelim = case feedType of
-          XmlFeed -> ""
+          XmlFeed  -> ""
           JsonFeed -> ", "
 
     body <- makeItem =<< applyJoinTemplateList itemDelim itemTpl itemContext' protectedItems
@@ -159,7 +159,7 @@ renderFeed feedType feedTpl itemTpl config itemContext items = do
         email -> constField "authorEmail" email
 
     escapeDescription = case feedType of
-        XmlFeed -> id
+        XmlFeed  -> id
         JsonFeed -> mapContextBy (== "description") escapeString
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -235,6 +235,10 @@ makeItemContext :: String -> Context a -> Context a
 makeItemContext fmt context = mconcat
     [context, dateField "published" fmt, dateField "updated" fmt]
 
+
+--------------------------------------------------------------------------------
+-- | Escape the string with the usual Haskell escape conventions while leaving
+-- the non-ASCII characters intact.
 escapeString :: String -> String
 escapeString = flip escapeString' ""
   where

--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -223,6 +223,9 @@ renderAtom = renderAtomWithTemplates atomTemplate atomItemTemplate
 
 --------------------------------------------------------------------------------
 -- | Render a JSON feed with a number of items.
+--
+-- Items' bodies will be put into @content_html@ field of the resulting JSON;
+-- the @content@ field will not be set.
 renderJson :: FeedConfiguration       -- ^ Feed configuration
            -> Context String          -- ^ Item context
            -> [Item String]           -- ^ Feed items

--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -40,10 +40,9 @@ import           Hakyll.Web.Template.List
 
 
 --------------------------------------------------------------------------------
-import           Data.Char                   (ord)
 import           Data.FileEmbed              (makeRelativeToProject)
-import           Numeric                     (showHex)
 import           System.FilePath             ((</>))
+import Text.Printf (printf)
 
 
 --------------------------------------------------------------------------------
@@ -256,7 +255,4 @@ escapeString = flip escapeString' ""
       | otherwise = showChar c (escapeString' cs s)
 
     escapeChar :: Char -> ShowS
-    -- We can pad with fixed number of zeros, because
-    -- `escapeChar` will only be called for characters
-    -- 0x00 - 0x1F
-    escapeChar c' = showString "\\u00" . showHex (ord c')
+    escapeChar = showString . printf "\\u%04X"

--- a/lib/Hakyll/Web/Feed.hs
+++ b/lib/Hakyll/Web/Feed.hs
@@ -67,13 +67,13 @@ atomItemTemplate =
     $(makeRelativeToProject ("data" </> "templates" </> "atom-item.xml")
         >>= embedTemplate)
 
-jsonFeedTemplate :: Template
-jsonFeedTemplate =
+jsonTemplate :: Template
+jsonTemplate =
     $(makeRelativeToProject ("data" </> "templates" </> "feed.json")
         >>= embedTemplate)
 
-jsonFeedItemTemplate :: Template
-jsonFeedItemTemplate =
+jsonItemTemplate :: Template
+jsonItemTemplate =
     $(makeRelativeToProject ("data" </> "templates" </> "feed-item.json")
         >>= embedTemplate)
 
@@ -228,7 +228,7 @@ renderJson :: FeedConfiguration       -- ^ Feed configuration
            -> Context String          -- ^ Item context
            -> [Item String]           -- ^ Feed items
            -> Compiler (Item String)  -- ^ Resulting feed
-renderJson = renderJsonWithTemplates jsonFeedTemplate jsonFeedItemTemplate
+renderJson = renderJsonWithTemplates jsonTemplate jsonItemTemplate
 
 
 --------------------------------------------------------------------------------

--- a/web/tutorials/05-snapshots-feeds.markdown
+++ b/web/tutorials/05-snapshots-feeds.markdown
@@ -1,5 +1,5 @@
 ---
-title: Snapshots, and how to produce an RSS/Atom feed
+title: Snapshots, and how to produce an RSS/Atom/JSON feed
 author: Jasper Van der Jeugt
 type: main
 ---

--- a/web/tutorials/05-snapshots-feeds.markdown
+++ b/web/tutorials/05-snapshots-feeds.markdown
@@ -7,7 +7,7 @@ type: main
 Basic feed configuration
 ------------------------
 
-Hakyll has built-in support for two types of feeds: RSS and Atom. This tutorial
+Hakyll has built-in support for three types of feeds: RSS, Atom and JSON. This tutorial
 explains how you can add these to your blog or website. The first step is to
 define a `FeedConfiguration` to set some basic options. For example, a cooking
 blog may have the following declaration:
@@ -26,7 +26,7 @@ myFeedConfiguration = FeedConfiguration
 Simple feed rendering
 ---------------------
 
-Now, let's look at how we actually create a feed. Two functions are available:
+Now, let's look at how we actually create a feed. Three functions are available:
 
 ```haskell
 renderAtom :: FeedConfiguration
@@ -42,8 +42,15 @@ renderRss :: FeedConfiguration
           -> Compiler (Item String)
 ```
 
+```haskell
+renderJson :: FeedConfiguration
+           -> Context String
+           -> [Item String]
+           -> Compiler (Item String)
+```
+
 As you can see, they have exactly the same signature: we're going to use
-`renderAtom` in this tutorial, but it's trivial to change this to an RSS feed.
+`renderAtom` in this tutorial, but it's trivial to change this to an RSS or JSON feed.
 
 ```haskell
 create ["atom.xml"] $ do
@@ -60,7 +67,7 @@ There we go! We simply take the 10 last posts and pass them to `renderAtom`,
 with our configuration and a `Context`.
 
 It's a bit of a problem that we don't have a description for our posts, and the
-Atom/RSS feed renderer requires this. One option is to add a `description: Foo`
+Atom/RSS/JSON feed renderer requires this. One option is to add a `description: Foo`
 header to our all posts. However, the description is the body text as it appears
 in most RSS readers, so we would prefer to include the entire content of the
 posts here.


### PR DESCRIPTION
> The JSON Feed format is a pragmatic syndication format, like [RSS](http://cyber.harvard.edu/rss/rss.html) and [Atom](https://tools.ietf.org/html/rfc4287), but with one big difference: it’s JSON instead of XML.

This PR adds JSON Feed support to Hakyll with a pretty barebone template, conforming to the [JSON Feed 1.1 spec](https://www.jsonfeed.org/version/1.1/). I have deployed it to my [personal blog](https://ozkutuk.me/feed.json) to serve as a working example, and it seems to work without any issues.