### PR TITLE
Add www.haskell.org to examples.

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -18,6 +18,8 @@ directly with the default Hakyll site.
 
 - <http://jaspervdj.be/>,
   [source](https://github.com/jaspervdj/jaspervdj)
+- <https://www.haskell.org/>,
+  [source](https://github.com/haskell-infra/www.haskell.org/)
 - <http://www.imagination-land.org/>,
   [source](https://github.com/Keruspe/blog/)
 - <https://bananasandlenses.net/>,


### PR DESCRIPTION
I recently noticed that <https://www.haskell.org/> is now generated through Hakyll, and yet there is no mention of it in the list of examples.  I think Hakyll deserves to toot its horn a bit and include it in its list of examples. :)