### PR TITLE
CI: update Stack and GHC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,12 @@ jobs:
           - os: windows-2022
             ghc: 9.2.5
         include:
-          # use a GHC version that only exists in chocolatey, to fix https://github.com/haskell/actions/issues/129 mentioned above
+          # https://github.com/haskell/actions/issues/129 advises to use
+          # 9.2.5.1, but it's broken somehow too: GHC gets installed, but then
+          # chocolatey claims that "all install methods for ghc 9.2.5.1
+          # failed". So let's use the next big thing
           - os: windows-2022
-            ghc: 9.2.5.1
+            ghc: 9.2.6
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,13 @@ jobs:
           # fails to build: "can't load framework: Cocoa (not found)"
           - os: macOS-11
             ghc: 8.8.4
+          # haskell/actions/setup fails to install this version because of chocolatey: https://github.com/haskell/actions/issues/129
+          - os: windows-2022
+            ghc: 9.2.5
+        include:
+          # use a GHC version that only exists in chocolatey, to fix https://github.com/haskell/actions/issues/129 mentioned above
+          - os: windows-2022
+            ghc: 9.2.5.1
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           - "8.8.4"
           - "8.10.7"
           - "9.0.2"
-          - "9.2.4"
+          - "9.2.5"
         exclude:
           # fails to build: "can't load framework: Cocoa (not found)"
           - os: macOS-11
@@ -70,8 +70,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        stack: ["2.9.1"]
-        ghc: ["9.0.2"]
+        stack: ["2.9.3"]
+        ghc: ["9.2.5"]
 
     steps:
     - uses: actions/checkout@v2
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         cabal: ["3.6"]
-        ghc: ["9.2.4"]
+        ghc: ["9.2.5"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
New versions are the ones recommended by `ghcup tui`. Also, the Stack CI job uses the same GHC (9.2.5) as the Stackage LTS snapshot we're using does (lts-20.10).