### PR TITLE
Clean up examples.

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -14,77 +14,37 @@ directly with the default Hakyll site.
 
 [Hakyll CSS garden]: http://katychuang.com/hakyll-cssgarden/gallery/
 
-## Hakyll 4
-
-- <http://jaspervdj.be/>,
+- <https://jaspervdj.be/>,
   [source](https://github.com/jaspervdj/jaspervdj)
 - <https://www.haskell.org/>,
   [source](https://github.com/haskell-infra/www.haskell.org/)
-- <http://www.imagination-land.org/>,
+- <https://www.imagination-land.org/>,
   [source](https://github.com/Keruspe/blog/)
-- <https://bananasandlenses.net/>,
-  [source](https://github.com/denisshevchenko/bananasandlenses)
-- <http://blog.clement.delafargue.name/>,
+- <https://blog.clement.delafargue.name/>,
   [source](https://github.com/divarvel/blog)
-- <http://bneijt.nl>,
-  [source](https://github.com/bneijt/bneijt.nl)
-- <http://brianshourd.com/>,
-  [source](https://github.com/brianshourd/brianshourd.com)
-- <http://variadic.me>,
-  [source](https://github.com/eakron/variadic.me)
-- <http://yannesposito.com/>,
-  [source](https://github.com/yogsototh/yblog)
-- <http://dannysu.com/>,
+- <https://dannysu.com/>,
   [source](https://github.com/dannysu/hakyll-blog)
-- <http://meta.plasm.us/>,
+- <https://meta.plasm.us/>,
   [source](https://github.com/travisbrown/metaplasm)
-- <http://workforpizza.com/>,
-  [source](https://github.com/irneh/workforpizza)
 - <http://poleiro.info/>,
   [source](https://github.com/arthuraa/poleiro)
-- <http://www.austinrochford.com/>,
-  [source](https://github.com/AustinRochford/blog)
-- <http://www.regisfoucault.com/>,
-  [source](https://github.com/regisfoucault/blog)
-- <http://www.chaoxuprime.com/>,
+- <https://www.chaoxuprime.com/>,
   [source](https://github.com/chaoxu/chaoxu.github.io/tree/develop)
-- <http://www.skybluetrades.net/>,
-  [source](https://github.com/ian-ross/blog)
-- <http://chromaticleaves.com/>,
-  [source](https://github.com/ericrasmussen/chromaticleaves)
-- <http://www.clever-cloud.com/en/>,
-  [source](https://github.com/CleverCloud/clever-cloud.com)
-- <http://blaenkdenum.com/>,
+- <https://blaenkdenum.com/>,
   [source](https://github.com/blaenk/blaenk.github.io)
-- <https://xinitrc.de/>,
-  [source](https://github.com/xinitrc/xinitrc.de)
-- <http://nickcharlton.net/>,
-  [source](https://github.com/nickcharlton/nickcharlton.net)
-- <http://www.eanalytica.com/>,
-  [literate source](http://www.eanalytica.com/site/)
-- <http://cse.iitk.ac.in/users/ppk>,
-  [source](https://github.com/piyush-kurur-pages/website)
-- <http://web.engr.oregonstate.edu/~walkiner/>,
-  [source](https://github.com/walkie/WebPage)
-- <http://techblog.rosedu.org/>,
+- <https://techblog.rosedu.org/>,
   [source](https://github.com/rosedu/techblog)
-- <http://freizl.github.io>,
-  [source](https://github.com/freizl/freizl.github.com/tree/master/build)
-- <http://www.gwern.net/>,
+- <https://www.gwern.net/>,
   [source](https://github.com/gwern/gwern.net)
-- <http://www.corentindupont.info/>,
-  [source](https://github.com/cdupont/CorentinDupont-WebPage)
-- <http://jelv.is>,
+- <https://jelv.is>,
   [source](https://github.com/TikhonJelvis/website)
-- <https://secure.plaimi.net/>,
-  [source](https://github.com/plaimi/www)
-- <http://duplode.github.io/>,
+- <https://duplode.github.io/>,
   [source](https://github.com/duplode/duplode.github.io/tree/sources)
-- <http://tzemanovic.github.io/>,
-  [source](https://github.com/tzemanovic/tzemanovic)
-- <http://listx.github.io>,
+- <https://tzemanovic.gitlab.io/>,
+  [source](https://gitlab.com/tzemanovic/tzemanovic.gitlab.io)
+- <https://listx.github.io>,
   [source](https://github.com/listx/listx_blog)
-- <http://kyle.marek-spartz.org>,
+- <https://kyle.marek-spartz.org>,
   [source](https://github.com/zeckalpha/kyle.marek-spartz.org)
 - <http://ladatura-corsets.com/>,
   [source](https://github.com/dsferruzza/datura-corsets)
@@ -92,98 +52,68 @@ directly with the default Hakyll site.
   [source](https://github.com/rbros/reichertbrothers.com)
 - <http://alemedeiros.sdf.org>,
   [source](https://github.com/alemedeiros/homepage)
-- <http://www.haskell.mn>,
-  [source](https://github.com/HaskellMN/www.haskell.mn)
-- <https://axiomatic.neophilus.net/>,
-  [source](https://github.com/Libbum/AxiomaticSemantics)
-- [https://tesser.org/](http://web.archive.org/web/20161022221713/https://tesser.org/),
-  [source](https://github.com/fractalcat/tesser.org)
-- <https://weien.io/>,
+- <https://www.haskellmn.org/>,
+  [source](https://github.com/HaskellMN/www.haskellmn.org)
+- <https://wei2912.github.io/>,
   [source](https://github.com/wei2912/blog-src)
-- <http://www.metasepi.org/>,
+- <https://metasepi.org/>,
   [source](https://github.com/metasepi/metasepi-website)
-- <http://gisli.hamstur.is/>,
+- <https://gisli.hamstur.is/>,
   [source](https://github.com/gislik/gisli.hamstur.is)
-- <http://blog.ssanj.net/>,
+- <https://blog.ssanj.net/>,
   [source](https://github.com/ssanj/babyloncandle)
-- <http://ruhaskell.org/>,
+- <https://ruhaskell.org/>,
   [source](https://github.com/ruHaskell/ruhaskell)
 - <http://www.haskell.od.ua/>,
   [source](https://github.com/odhug/odhug.github.com)
-- <http://blog.rekahsoft.ca/>,
-  [source](http://git.rekahsoft.ca/blog-rekahsoft-ca)
-- <http://www.andreascarpino.it>,
-  [source](https://gitlab.com/ilpianista/website)
-- <http://cascadeofinsights.com/>,
-  [source](https://github.com/agbell/agbell.github.io/tree/hakyll)
+- <https://blog.rekahsoft.ca/>,
+  [source](https://git.rekahsoft.ca/rekahsoft/blog-rekahsoft-ca)
+- <https://adamgordonbell.com/>,
+  [source](https://github.com/adamgordonbell/agbell.github.io/tree/hakyll)
 - <http://www.xoltar.org/>,
   [source](https://github.com/xoltar/xoltar.org)
-- <http://sigkill.dk/>
+- <https://sigkill.dk/>
   [literate source](http://sigkill.dk/programs/sigkill.html)
-- <http://curry-club-augsburg.de/>,
+- <https://curry-club-augsburg.de/>,
   [source](https://github.com/curry-club-aux/curry-club-augsburg.de)
-- <http://ismailmustafa.com/>,
-  [source](https://github.com/ismailmustafa/ismailmustafa.github.io/tree/hakyll)
-- <http://lettier.github.io/>,
+- <https://lettier.github.io/>,
   [source](https://github.com/lettier/lettier.github.io)
-- <http://raindev.io>,
-  [source](https://github.com/raindev/raindev.github.io)
-- <http://hal2016.haskell.org/>,
+- <https://hal2016.haskell.org/>,
   [source](https://github.com/nomeata/hal2016-website/)
-- <http://acehack.org/>,
+- <https://acehack.org/>,
   [source](https://github.com/sakshamsharma/acehack/)
 - <https://nek0.eu/>,
-  [source](https://github.com/nek0/nek0.eu)
-- <http://static-dust.klpn.se/>,
+  [source](https://gitea.nek0.eu/nek0/nek0.eu)
+- <https://static-dust.klpn.se/>,
   [source](https://github.com/klpn/static-dust)
-- <http://www.kuznero.com/>,
-  [source](https://github.com/kuznero/kuznero.github.io)
-- <http://nicolerauch.de/>,
+- <https://nicolerauch.de/>,
   [source](https://github.com/NicoleRauch/BusinessWebsite)
-- <http://johnduhamel.io/>,
+- <https://johnduhamel.io/>,
   [source](https://github.com/jjduhamel/blog)
-- <http://alexanderlobov.ru/>,
-  [source](https://github.com/alexanderlobov/homepage)
-- <http://www.rosanbo.com/>,
+- <https://www.rosanbo.com/>,
   [source](https://github.com/polo2ro/blog)
 - <http://limansky.me/>,
   [source](https://github.com/limansky/limansky_me)
-- <http://rahul.nu/>,
-  [source](https://github.com/rp/rp.github.io/tree/dev)
-- <http://haskanything.com/>,
-  [source](https://github.com/beerendlauwers/HaskAnything)
-- <https://anler.me/>,
-  [source](https://github.com/anler/anler.me)
-- <http://argumatronic.com/>,
-  [source](https://gitlab.com/GinBaby/argumatronic/tree/master)
-- <http://sillybytes.net/>,
+- <https://rahul.sh/>,
+  [source](https://gitlab.com/rp/rp.gitlab.io)
+- <https://argumatronic.com/>,
+  [source](https://github.com/argumatronic/argumatronic)
+- <https://sillybytes.net/>,
   [source](https://github.com/sillybytes/sillybytes)
-- <https://falconpilot.github.io/>,
-  [source](https://github.com/FalconPilot/falconpilot.github.io)
-- <http://spyhop.cafe/>,
-  [source](https://github.com/thunky-monk/spyhop-cafe)
 - <https://bendo.github.io/>,
-  [source](https://github.com/bendo/bendo.github.io)
-- <http://adarsh.cc/>,
+  [source](https://github.com/bendo/bendo.github.io/tree/dev)
+- <https://adarsh.cc/>,
   [source](https://github.com/adarshp/adarsh.cc)
-- <http://0a.io>,
-  [source](https://github.com/arrchyy/0a.io)
+- <https://0a.io/>,
+  [source](https://github.com/archywillhe/0a.io-v0)
 - <https://nasy.moe/>,
   [source](https://github.com/nasyxx/NasyMoe)
-- <http://uniprocess.org/>,
+- <https://uniprocess.org/>,
   [source](https://gitlab.com/uniprocess/uniprocess.org)
-- <https://regularflolloping.com/>,
-  [source](https://github.com/techieAgnostic/rf)
-- <http://enter-haken.github.io/>,
+- <https://enter-haken.github.io/>,
   [source](https://github.com/enter-haken/blog)
-- <https://modular.blind.guru/>,
-  [source](https://github.com/mlang/eurorack-metadata)
-- <http://www.jonashietala.se/>,
-  [source](https://github.com/treeman/jonashietala)
 - <https://abhinavsarkar.net/>,
-  [source](https://github.com/abhin4v/abhin4v.github.io)
-- <https://dailyreadingnotes.com/>,
-  [source](https://github.com/hackeryarn/daily-reading-notes)
+  [source](https://github.com/abhin4v/abhin4v.github.io/tree/source)
 - <https://benedikt-mayer.github.io/>,
   [source](https://github.com/benedikt-mayer/benedikt-mayer.github.io)
 - <https://svejcar.dev/>,
@@ -192,49 +122,23 @@ directly with the default Hakyll site.
   [source](https://github.com/rpearce/robertwpearce.com)
 - <https://blog.thjread.com/>,
   [source](https://github.com/thjread/thjread-blog)
-- <https://xvw.github.io/>,
-  [source](https://github.com/xvw/planet)
 - <https://jeancharles.quillet.org/>,
   [source](https://github.com/jecaro/jeancharles.quillet)
 - <https://nliu.net/>,
   [source](https://github.com/dreamsmasher/site-haskell-source)
 - <https://dukzcry.github.io/>,
   [source](https://github.com/dukzcry/dukzcry.github.io)
-- <https://mista.me>,
-  [source](https://github.com/agustinmista/website/tree/master)
+- <https://www.mista.me/>,
+  [source](https://github.com/agustinmista/website)
 - <https://blog.marbu.eu/>,
   [source](https://github.com/marbu/blog-marbu-eu)
 - <https://aerphanas.github.io/>,
   [source](https://github.com/aerphanas/aerphanas.github.io)
-- <https://blog.galowicz.de>,
-  [source](https://github.com/tfc/tfc.github.io)
-
-
-## Hakyll 3.X
-
-- <http://ethanschoonover.com/>,
-  [source](https://github.com/altercation/ethanschoonover.com)
-- <http://extralogical.net/>,
-  [source](https://github.com/beastaugh/extralogical.net)
-- <http://blog.demotera.com/>,
-  [source](https://bitbucket.org/paul_r/blog-de-demotera)
-- <http://projects.haskell.org/diagrams/>,
-  [source](http://patch-tag.com/r/byorgey/diagrams-doc/snapshot/current/content/pretty/web/)
-- <http://wunki.org>,
-  [source](https://github.com/wunki/wunki.org)
-- <http://rs.io>,
-  [source](https://github.com/robertseaton/rs.io/)
-- <http://blog.coldflake.com/>,
-  [source](https://github.com/marcmo/blog.coldflake)
-- <http://deepak.jois.name>,
-  [source](https://github.com/deepakjois/website)
-- <http://orftz.com>,
-  [source](https://github.com/orftz/orftz.com)
-- <http://citationneeded.me/>,
-  [literate source](http://citationneeded.me/hakyll.html)
-- <http://shakthimaan.com/news.html>,
-  [source](http://gitorious.org/shakthimaan-blog)
+- <https://galowicz.de/>,
+  [source](https://github.com/tfc/tfc.github.io/tree/develop)
+- <https://diagrams.github.io/>,
+  [source](https://github.com/diagrams/diagrams-doc)
 - <http://www.alfredodinapoli.com/>,
-  [source](https://github.com/CharlesStain/alfredodinapoli.com)
-- <http://michaelxavier.net>,
+  [source](https://github.com/adinapoli/alfredodinapoli.com)
+- <https://michaelxavier.net>,
   [source](https://github.com/michaelxavier/michaelxavier.net)


### PR DESCRIPTION
A lot of examples have accumulated, but over the years many of them have disappeared or moved on.  I was looking at the source code for the examples to learn anything that I might later find useful on my own site; noting which sites have disappeared, changed addresses, or migrated to other systems was a natural byproduct.

This change does the following:

*   Remove sites that no longer exist or no longer use Hakyll.
*   Remove sites whose source code is no longer public.
*   Updated addresses for sites and/or source code repositories.
*   Change `http` addresses to `https` addresses when possible.
*   There are no more Hakyll 3 sites; they have all moved to Hakyll 4, migrated to other systems, or disappeared.