### PR TITLE
CI: re-enable GHC <8.10.6 on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,12 +29,6 @@ jobs:
           # fails to build: "can't load framework: Cocoa (not found)"
           - os: macOS-12
             ghc: "8.8.4"
-          # fails to build easy-file on which we depend: https://github.com/jaspervdj/hakyll/issues/988
-          - os: windows-2022
-            ghc: "8.6.5"
-          # fails to build easy-file on which we depend: https://github.com/jaspervdj/hakyll/issues/988
-          - os: windows-2022
-            ghc: "8.8.4"
           # fails to link: https://github.com/jaspervdj/hakyll/issues/986
           - os: windows-2022
             ghc: "9.6.1"


### PR DESCRIPTION
easy-file 0.2.5 fixes the build issue that 0.2.4 had, so we can re-enable the affected compilers now.

Fixes #988.