### PR TITLE
CI: re-enable GHC 9.6.1 on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,6 @@ jobs:
           # fails to build: "can't load framework: Cocoa (not found)"
           - os: macOS-12
             ghc: "8.8.4"
-          # fails to link: https://github.com/jaspervdj/hakyll/issues/986
-          - os: windows-2022
-            ghc: "9.6.1"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The issue in the network package seem to be fixed, so let's retry the build.

Fixes #986.