### PR TITLE
Allow tasty 1.5

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -284,7 +284,7 @@ Test-suite hakyll-tests
   Build-Depends:
     hakyll,
     QuickCheck                 >= 2.8  && < 2.15,
-    tasty                      >= 0.11 && < 1.5,
+    tasty                      >= 0.11 && < 1.6,
     tasty-golden               >= 2.3  && < 2.4,
     tasty-hunit                >= 0.9  && < 0.11,
     tasty-quickcheck           >= 0.8  && < 0.11,


### PR DESCRIPTION
Tested with GHC 9.2.8 and `for action in build test ; do cabal $action --enable-tests --constrain 'tasty == 1.5' || break ; done` — all tests pass fine.