### PR TITLE
Fix broken link to Clay preprocessor

### DIFF
--- a/web/tutorials/using-clay-with-hakyll.markdown
+++ b/web/tutorials/using-clay-with-hakyll.markdown
@@ -4,7 +4,7 @@ author: Jasper Van der Jeugt
 type: article
 ---
 
-[Clay](http://sebastiaanvisser.github.com/clay/) is a nice CSS preprocesser
+[Clay](https://github.com/sebastiaanvisser/clay) is a nice CSS preprocesser
 written in Haskell. There are multiple options to use this together with Hakyll,
 but in this short tutorial I focus on what I think is the best way.
 


### PR DESCRIPTION
Kudos to @JHaugh4 for spotting this and providing the correct link.

Fixes #1005.