### PR TITLE
Allow bytestring 0.12

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -188,7 +188,7 @@ Library
     binary               >= 0.5      && < 0.10,
     blaze-html           >= 0.5      && < 0.10,
     blaze-markup         >= 0.5.1    && < 0.9,
-    bytestring           >= 0.9      && < 0.12,
+    bytestring           >= 0.9      && < 0.13,
     containers           >= 0.3      && < 0.7,
     data-default         >= 0.4      && < 0.8,
     deepseq              >= 1.3      && < 1.5,
@@ -291,7 +291,7 @@ Test-suite hakyll-tests
     -- Copy pasted from hakyll dependencies:
     aeson                >= 1.0      && < 1.6 || >= 2.0 && < 2.3,
     base                 >= 4.12     && < 5,
-    bytestring           >= 0.9      && < 0.12,
+    bytestring           >= 0.9      && < 0.13,
     containers           >= 0.3      && < 0.7,
     filepath             >= 1.0      && < 1.5,
     tagsoup              >= 0.13.1   && < 0.15,


### PR DESCRIPTION
Tested with `for action in build test ; do cabal $action --enable-tests --constrain 'bytestring == 0.12.0.2' || break ; done`.