### PR TITLE
Allow text 2.1

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -295,7 +295,7 @@ Test-suite hakyll-tests
     containers           >= 0.3      && < 0.7,
     filepath             >= 1.0      && < 1.5,
     tagsoup              >= 0.13.1   && < 0.15,
-    text                 >= 0.11     && < 1.3 || >= 2.0 && < 2.1,
+    text                 >= 0.11     && < 1.3 || >= 2.0 && < 2.2,
     unordered-containers >= 0.2      && < 0.3,
     yaml                 >= 0.8.11   && < 0.12
 


### PR DESCRIPTION
Tested with GHC 9.4.8: `for action in build test ; do cabal $action --enable-tests --constrain 'text == 2.1' || break ; done`.