### PR TITLE
Allow file-embed 0.0.16

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -193,7 +193,7 @@ Library
     data-default         >= 0.4      && < 0.8,
     deepseq              >= 1.3      && < 1.6,
     directory            >= 1.2.7.0  && < 1.4,
-    file-embed           >= 0.0.10.1 && < 0.0.16,
+    file-embed           >= 0.0.10.1 && < 0.0.17,
     filepath             >= 1.0      && < 1.5,
     hashable             >= 1.0      && < 2,
     lrucache             >= 1.1.1    && < 1.3,


### PR DESCRIPTION
Tested with `for action in build test ; do cabal $action --enable-tests --constrain 'file-embed == 0.0.16.0' || break ; done` with GHC 9.4.8 on Linux.