### PR TITLE
Add variants of pandoc renderer and compiler for items

### DIFF
--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -10,12 +10,14 @@ module Hakyll.Web.Pandoc
     , renderPandocWith
     , renderPandocWithTransform
     , renderPandocWithTransformM
+    , renderPandocItemWithTransformM
 
       -- * Derived compilers
     , pandocCompiler
     , pandocCompilerWith
     , pandocCompilerWithTransform
     , pandocCompilerWithTransformM
+    , pandocItemCompilerWithTransformM
 
       -- * Default options
     , defaultHakyllReaderOptions
@@ -133,6 +135,21 @@ renderPandocWithTransformM ropt wopt f i =
 
 
 --------------------------------------------------------------------------------
+-- | Like 'renderPandocWithTransformM', but work on an 'Item' 'Pandoc' instead
+-- of just a 'Pandoc'. This allows for more seamless composition of functions
+-- that require the extra information that an 'Item' provides, like
+-- bibliographic transformations with
+-- 'Hakyll.Web.Pandoc.Biblio.processPandocBiblio'.
+renderPandocItemWithTransformM
+  :: ReaderOptions -> WriterOptions
+  -> (Item Pandoc -> Compiler (Item Pandoc))
+  -> Item String
+  -> Compiler (Item String)
+renderPandocItemWithTransformM ropt wopt f i =
+    writePandocWith wopt <$> (f =<< readPandocWith ropt i)
+
+
+--------------------------------------------------------------------------------
 -- | Read a page render using pandoc
 pandocCompiler :: Compiler (Item String)
 pandocCompiler =
@@ -168,6 +185,20 @@ pandocCompilerWithTransformM :: ReaderOptions -> WriterOptions
                     -> Compiler (Item String)
 pandocCompilerWithTransformM ropt wopt f =
     getResourceBody >>= renderPandocWithTransformM ropt wopt f
+
+
+--------------------------------------------------------------------------------
+-- | Like 'pandocCompilerWithTransformM', but work on an 'Item' 'Pandoc'
+-- instead of just a 'Pandoc'. This allows for more seamless composition of
+-- functions that require the extra information that an 'Item' provides, like
+-- bibliographic transformations with
+-- 'Hakyll.Web.Pandoc.Biblio.processPandocBiblio'.
+pandocItemCompilerWithTransformM
+  :: ReaderOptions -> WriterOptions
+  -> (Item Pandoc -> Compiler (Item Pandoc))
+  -> Compiler (Item String)
+pandocItemCompilerWithTransformM ropt wopt f =
+    getResourceBody >>= renderPandocItemWithTransformM ropt wopt f
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Add `renderPandocItemWithTransformM` and `pandocItemCompilerWithTransformM`, which work like the respective functions without the "item" infix, but the transformation function is a monadic "Item Pandoc -> Item Pandoc" instead of just a "Pandoc -> Pandoc". This allows one to more seamlessly compose functions that do require the extra information that an item provides, like bibliographic transformations.

---

My specific use-case for this is exactly adding a nicely formatted bibliography at the end of certain pages.
Here is a real world example with entirely too much code:

``` haskell
myPandocCompiler :: Compiler (Item String)
myPandocCompiler =
  pandocItemCompilerWithTransformM                     -- ⋘ HERE
    readerOpts
    writerOpts
    (traverse moreSettings <=< processBib)
 where
  processBib :: Item Pandoc -> Compiler (Item Pandoc)  -- Due to this type
  processBib pandoc = do
    csl <- load @CSL    "bib/style.csl"
    bib <- load @Biblio "bib/bibliography.bib"
    -- We do want to link citations.
    p <- withItemBody
           (\(Pandoc (Meta meta) bs) -> pure $
             Pandoc (Meta $ Map.insert "link-citations" (MetaBool True) meta)
                    bs)
           pandoc
    fmap (tableiseBib . insertRefHeading) <$> processPandocBiblio csl bib p
   where
    -- Insert a heading for the citations.
    insertRefHeading :: Pandoc -> Pandoc
    insertRefHeading = walk $ concatMap \case
      d@(Div ("refs", _, _) _) -> [Header 1 ("references", [], []) [Str "References"], d]
      block                    -> [block]

    -- Arrange all citations in a table, so that they are nicely aligned.
    -- This probably only works with label or numerical styles.
    tableiseBib :: Pandoc -> Pandoc
    tableiseBib = walk \case
      Div a@("refs", _, _) body -> Div a (Many.toList (simpleTable [] (map citToRow body)))
      body                      -> body
     where
      citToRow :: Block -> [Many Block]
      citToRow = map Many.singleton . \case
        Div attr [Para (s1 : ss)] -> [Div attr [Plain [s1]], Plain [Space], Plain ss]
        d                         -> error $ "citToRow: unexpected citation format: " <> show d
```
