### PR TITLE
Allow warp 3.4

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -219,7 +219,7 @@ Library
   If flag(previewServer)
     Build-depends:
       wai             >= 3.2   && < 3.3,
-      warp            >= 3.2   && < 3.4,
+      warp            >= 3.2   && < 3.5,
       http-types      >= 0.9   && < 0.13,
       fsnotify        >= 0.2   && < 0.5
     Cpp-options:


### PR DESCRIPTION
Tested with GHC 9.8.2:

```
for action in build test ; do cabal $action --enable-tests --flags '+previewServer' --constrain 'warp == 3.4.0' || break ; done
```
