### PR TITLE
Improve +watchServer and +previewServer flags

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -104,14 +104,17 @@ Source-Repository head
 Flag previewServer
   Description: Include the preview server
   Default:     True
+  Manual:      True
 
 Flag watchServer
   Description: Include the watch server
   Default:     True
+  Manual:      True
 
 Flag checkExternal
   Description: Include external link checking
   Default:     True
+  Manual:      True
 
 Flag buildWebsite
   Description: Build the hakyll website

--- a/lib/Hakyll/Commands.hs
+++ b/lib/Hakyll/Commands.hs
@@ -141,24 +141,30 @@ deploy conf = deploySite conf conf
 -- | Print a warning message about the preview serving not being enabled
 #ifndef PREVIEW_SERVER
 previewServerDisabled :: IO ()
-previewServerDisabled =
-    mapM_ putStrLn
-        [ "PREVIEW SERVER"
-        , ""
-        , "The preview server is not enabled in the version of Hakyll. To"
-        , "enable it, set the flag to True and recompile Hakyll."
-        , "Alternatively, use an external tool to serve your site directory."
-        ]
+previewServerDisabled = mapM_ putStrLn
+    [ "PREVIEW SERVER"
+    , ""
+    , "The preview server is not enabled in this version of Hakyll. To enable"
+    , "it, toggle the cabal configuration flag to True, for example by adding"
+    , "the following to your `cabal.project` file:"
+    , ""
+    , "    constraints: hakyll +previewServer"
+    , ""
+    , "Alternatively, use an external tool to serve your site directory."
+    ]
 #endif
 
 #ifndef WATCH_SERVER
 watchServerDisabled :: IO ()
-watchServerDisabled =
-    mapM_ putStrLn
-      [ "WATCH SERVER"
-      , ""
-      , "The watch server is not enabled in the version of Hakyll. To"
-      , "enable it, set the flag to True and recompile Hakyll."
-      , "Alternatively, use an external tool to serve your site directory."
-      ]
+watchServerDisabled = mapM_ putStrLn
+    [ "WATCH SERVER"
+    , ""
+    , "The watch server is not enabled in this version of Hakyll. To enable"
+    , "it, toggle the cabal configuration flag to True, for example by adding"
+    , "the following to your `cabal.project` file:"
+    , ""
+    , "    constraints: hakyll +watchServer"
+    , ""
+    , "Alternatively, use an external tool to serve your site directory."
+    ]
 #endif


### PR DESCRIPTION
 -  Make these flags manual so they can't be turned off by cabal without the user knowing about it.
 -  Improve error message to mention how to override them in `cabal.project`.

See #1022