### PR TITLE
faq: Add another possible encoding error

### DIFF
--- a/web/tutorials/faq.markdown
+++ b/web/tutorials/faq.markdown
@@ -18,6 +18,10 @@ or:
 It means that your Hakyll executable couldn't write to (in the former case) or
 read (in the latter) from an UTF-8 encoded file.
 
+Another possible encoding error is:
+
+    Store.set: invalid argument (cannot decode byte sequence starting from 197)
+
 On most linux distros, you can solve this by setting your `LANG` to use UTF-8,
 using something like:
 


### PR DESCRIPTION
I got an error 

```
Store.set: invalid argument (cannot decode byte sequence starting from 197)
```

This is different from the encoding errors listed, but I was still able to solve it by setting `LANG`.

EDIT: I added the error after the other two because I can't tell whether it happens during read or write.