### PR TITLE
Allow pandoc 3.2

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -254,7 +254,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.2
+      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.3
     Cpp-options:
       -DUSE_PANDOC
 
@@ -321,7 +321,7 @@ Test-suite hakyll-tests
     Cpp-options:
       -DUSE_PANDOC
     Build-Depends:
-      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.2
+      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.3
 
 
 Executable hakyll-init
@@ -355,4 +355,4 @@ Executable hakyll-website
     base      >= 4.12  && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.6,
-    pandoc    >= 2.11  && < 2.20 || >= 3.0 && < 3.2
+    pandoc    >= 2.11  && < 2.20 || >= 3.0 && < 3.3


### PR DESCRIPTION
Tested with GHC 9.8.2 and `for action in build test ; do cabal $action --enable-tests --constrain 'pandoc == 3.2' || break ; done`.