### PR TITLE
Compatibility with GHC 9.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           - "9.4.8"
           - "9.6.5"
           - "9.8.2"
+          - "9.10.1"
         exclude:
           # fails to build: "can't load framework: Cocoa (not found)"
           - os: macOS-12

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -210,7 +210,7 @@ Library
     resourcet            >= 1.1      && < 1.4,
     scientific           >= 0.3.4    && < 0.4,
     tagsoup              >= 0.13.1   && < 0.15,
-    template-haskell     >= 2.14     && < 2.22,
+    template-haskell     >= 2.14     && < 2.23,
     text                 >= 0.11     && < 1.3 || >= 2.0 && < 2.2,
     time                 >= 1.8      && < 1.15,
     time-locale-compat   >= 0.1      && < 0.2,

--- a/lib/Hakyll/Core/Runtime.hs
+++ b/lib/Hakyll/Core/Runtime.hs
@@ -1,4 +1,5 @@
 --------------------------------------------------------------------------------
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 module Hakyll.Core.Runtime
     ( run
@@ -18,7 +19,10 @@ import           Data.Foldable                 (for_, traverse_)
 import qualified Data.Graph                    as Graph
 import           Data.IORef                    (IORef)
 import qualified Data.IORef                    as IORef
-import           Data.List                     (foldl', intercalate)
+import           Data.List                     (intercalate)
+#if !(MIN_VERSION_base(4,20,0))
+import           Data.List                     (foldl')
+#endif
 import           Data.Map                      (Map)
 import qualified Data.Map                      as Map
 import           Data.Maybe                    (fromMaybe)

--- a/src/Init.hs
+++ b/src/Init.hs
@@ -1,4 +1,5 @@
 --------------------------------------------------------------------------------
+{-# LANGUAGE CPP #-}
 module Main
     ( main
     ) where
@@ -8,7 +9,10 @@ module Main
 import           Control.Arrow         (first)
 import           Control.Monad         (forM, forM_)
 import           Data.Char             (isAlphaNum, isNumber)
-import           Data.List             (foldl', intercalate, isPrefixOf)
+import           Data.List             (intercalate, isPrefixOf)
+#if !(MIN_VERSION_base(4,20,0))
+import           Data.List             (foldl')
+#endif
 import           Data.Version          (Version (..))
 import           System.Directory      (canonicalizePath, copyFile,
                                         doesFileExist,


### PR DESCRIPTION
Bump the upper bound on template-haskell and enable CI for GHC-9.10.1.

Tested locally with GHC 9.10: All the tests run through. A metadata revision or minor release would be much appreciated :) 