### PR TITLE
Use HLint.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,0 +1,12 @@
+name: HLint
+on: [push, pull_request]
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload results to GitHub code scanning.
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/hlint-scan@v1

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,99 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Warnings currently triggered by your code
+- ignore: {name: "Evaluate"} # 1 hint
+- ignore: {name: "Functor law"} # 1 hint
+- ignore: {name: "Parse error: on input `pattern'"} # 11 hints
+- ignore: {name: "Redundant $"} # 8 hints
+- ignore: {name: "Redundant bracket"} # 11 hints
+- ignore: {name: "Redundant lambda"} # 1 hint
+- ignore: {name: "Redundant seq"} # 2 hints
+- ignore: {name: "Traversable law"} # 1 hint
+- ignore: {name: "Unused LANGUAGE pragma"} # 6 hints
+- ignore: {name: "Use ++"} # 3 hints
+- ignore: {name: "Use :"} # 1 hint
+- ignore: {name: "Use <$>"} # 8 hints
+- ignore: {name: "Use <&>"} # 3 hints
+- ignore: {name: "Use asks"} # 23 hints
+- ignore: {name: "Use concatMap"} # 1 hint
+- ignore: {name: "Use fewer imports"} # 6 hints
+- ignore: {name: "Use fmap"} # 7 hints
+- ignore: {name: "Use forM_"} # 1 hint
+- ignore: {name: "Use gets"} # 5 hints
+- ignore: {name: "Use intercalate"} # 1 hint
+- ignore: {name: "Use lambda-case"} # 11 hints
+- ignore: {name: "Use list comprehension"} # 1 hint
+- ignore: {name: "Use newtype instead of data"} # 2 hints
+- ignore: {name: "Use notElem"} # 1 hint
+- ignore: {name: "Use section"} # 1 hint
+- ignore: {name: "Use span"} # 1 hint
+- ignore: {name: "Use typeRep"} # 4 hints
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+# The hints are named by the string they display in warning messages.
+# For example, if you see a warning starting like
+#
+# Main.hs:116:51: Warning: Redundant ==
+#
+# You can refer to that hint with `{name: Redundant ==}` (see below).
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+#
+# Warn on use of partial functions
+# - group: {name: partial, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml


### PR DESCRIPTION
I thought it would be nice to have a linter, so this adds an [HLint](https://github.com/ndmitchell/hlint) workflow which [uploads its results to GitHub code scanning](https://github.com/haskell-actions/hlint-scan).  If you do not want a linter or prefer other ways to do linting, feel free to close this pull request without merging.

This change disables hints that would trigger for the existing code.  Depending on preference, some of them can be enabled later, while others could be permanently disabled.  E.g., removing a needless `$` seems a good idea, while I am not a fan of the suggestion to use `<&>` with Hakyll code.

To see what warnings and suggestions may look like, see https://github.com/haskell-actions/hlint-scan#examples.