### PR TITLE
Update Stack snapshot version in example command.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,4 +16,4 @@ Or using stack:
 
 If Stack fails, please [see which Stackage snapshots contain
 Hakyll](https://www.stackage.org/package/hakyll/snapshots) and specify one
-explicitly, e.g. `stack install --resolver=lts-19.0 hakyll`.
+explicitly, e.g. `stack install --resolver=lts-22.23 hakyll`.


### PR DESCRIPTION
It seems reasonable to update the Stack snapshot in the example command so that it is no longer 3 major versions behind.