### PR TITLE
Change location of "Fork me on GitHub" image.

### DIFF
--- a/web/templates/default.html
+++ b/web/templates/default.html
@@ -16,7 +16,7 @@
     </head>
     <body>
         <!-- Fork me on Github -->
-        <a href="https://github.com/jaspervdj/hakyll"><img style="position: absolute; top: 0; right: 0; border: 0; margin: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+        <a href="https://github.com/jaspervdj/hakyll"><img style="position: absolute; top: 0; right: 0; border: 0; margin: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
         <div id="main">
             <div id="header">
                 <a href="/">


### PR DESCRIPTION
The one on AWS no longer works, and the broken image has been bugging me for a while.  This changes it to the one specified on https://github.blog/news-insights/github-ribbons/.

I would really like to change it to something based on CSS and not an image (in particular, it would be easier to adjust with different color schemes if that is ever supported), but this is the minimum change to fix the broken image.