### PR TITLE
Style Hakyll website to better accommodate smaller screens.

### DIFF
--- a/web/css/default.css
+++ b/web/css/default.css
@@ -32,7 +32,7 @@ div#header a {
 
 div#main {
     margin: 0px auto 0px auto;
-    width: 860px;
+    max-width: 860px;
 }
 
 div#sidebar {
@@ -60,7 +60,7 @@ div#sidebar img {
 }
 
 div#content {
-    width: 670px;
+    max-width: 670px;
     float: right;
 }
 
@@ -107,6 +107,7 @@ img {
     border: none;
     display: block;
     margin: 6px auto 30px auto;
+    max-width: 100%;
 }
 
 ul {
@@ -130,4 +131,47 @@ pre code {
 
 p.caption {
     display: none;
+}
+
+@media all and (max-width: 900px) {
+    body {
+        padding: 0 0 1em 1em;
+    }
+
+    div#header {
+        margin: 24px 0px 12px 0px;
+    }
+
+    div#main {
+        max-width: 100%
+    }
+
+    div#sidebar {
+        margin-right: 0;
+        width: 100%;
+        float: none;
+        margin-bottom: 1em;
+        font-size: 75%;
+        opacity: 50%;
+    }
+
+    div#sidebar h1 {
+        float: none;
+    }
+
+    div#sidebar a {
+        display: inline;
+        float: none;
+        margin-bottom: initial;
+        padding-right: 2em;
+    }
+
+    div#sidebar img {
+        display: none;
+    }
+
+    div#content {
+        max-width: 100%;
+        float: none;
+    }
 }

--- a/web/css/default.css
+++ b/web/css/default.css
@@ -135,11 +135,11 @@ p.caption {
 
 @media all and (max-width: 900px) {
     body {
-        padding: 0 0 1em 1em;
+        padding: 0 1em 0 1em;
     }
 
     div#header {
-        margin: 24px 0px 12px 0px;
+        margin: 24px 0px 24px 0px;
     }
 
     div#main {

--- a/web/templates/default.html
+++ b/web/templates/default.html
@@ -13,6 +13,7 @@
         <!-- Metadata. -->
         <meta name="keywords" content="hakyll,static site generator,static,site,generator,haskell,blog"/>
         <meta name="description" content="Hakyll - A Static Site Generator in Haskell."/>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>
         <!-- Fork me on Github -->


### PR DESCRIPTION
This updates the HTML and stylesheet for the Hakyll website to better accommodate small screens, i.e., phones and such.  I feel like it's time it got the [same treatment](https://github.com/jaspervdj/hakyll/commit/9ce4870a3793b362ba2b5ff66a5957ac27c5ddb2) that the starter site did.

*   It leaves styling for bigger screens alone for the most part, except for using a `max-width` so that the width can be smaller on narrower displays, i.e., phone screens or narrow web browser windows.

*   It sets `viewport` in the HTML so that the styling will be based on the real dimensions of the screen, not the fake dimensions used by phones to display websites specifically tailored to a certain size on desktops.

*   On narrow screens, it overrides properties so that the presentation is better for a narrow width.

    * In particular, the navigation sidebar becomes a flatter set of links at the beginning of the page instead of being the vertical set of links it is on wider screens.  This let's one reach the main content quicker by not having to skip through more of the navigation links.  The font size is slightly smaller and translucent to make it easier to distinguish from the main content.

    * There is actually no `img` in the sidebar in the `default.html` template, but there is styling for it in the stylesheet.  Not wanting to touch the existing style unless I had to, I set it to not display an image in the sidebar to save space on small screens, in case one is added in the future.

Attached is a [screenshot](https://github.com/user-attachments/assets/531f4a59-f224-490f-a997-f3121934e862) with what the website would look like on my phone.


