### PR TITLE
`processPandocBiblio`: Honour `nocite` directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ title: Releases
 ## Hakyll (unreleased)
 
 - GHC 9.12 compatibility: bump `template-haskell` upper bound to include 2.23
+- Add support for `nocite` metadata field to `processPandocBiblio` and
+    `processPandocBiblios` (#1058) (contribution by Tony Zorman)
 
 ## Hakyll 4.16.4.0 (2024-12-08)
 
-- Fixed an issue where compressing CSS with `clamp` expressions would 
+- Fixed an issue where compressing CSS with `clamp` expressions would
     result in invalid CSS (#1021) (contribution by Laurent P. René de Cotret)
 - Added `boolFieldM` (#1044) (contribution by 0xd34df00d)
 - Run HLint as part of GitHub Actions (#1045) (contribution by Yoo Chung)
@@ -118,7 +120,7 @@ title: Releases
     Alexander Batischev)
 - Allow `pandoc` 3.0. Note that the behavior of Hakyll's `readPandocBiblios` and
     `readPandocBiblio` is different whether pandoc 2 or 3 is installed
-    (contribution by Laurent P. René de Cotret) 
+    (contribution by Laurent P. René de Cotret)
 - Bump `mtl` upper bound to allow 2.3 (contribution by Alexander Batischev)
 - Bump `pandoc` upper bound to allow 3.1 (contribution by Laurent P. René de
     Cotret)

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -252,7 +252,8 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.7
+      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.7,
+      pandoc-types >= 1.22 && < 1.24
     Cpp-options:
       -DUSE_PANDOC
 
@@ -317,7 +318,8 @@ Test-suite hakyll-tests
     Cpp-options:
       -DUSE_PANDOC
     Build-Depends:
-      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.7
+      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.7,
+      pandoc-types >= 1.22 && < 1.24
 
 
 Executable hakyll-init
@@ -351,4 +353,5 @@ Executable hakyll-website
     base      >= 4.12  && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.6,
-    pandoc    >= 2.11  && < 2.20 || >= 3.0 && < 3.7
+    pandoc    >= 2.11  && < 2.20 || >= 3.0 && < 3.7,
+    pandoc-types >= 1.22 && < 1.24

--- a/lib/Hakyll/Web/Pandoc/Biblio.hs
+++ b/lib/Hakyll/Web/Pandoc/Biblio.hs
@@ -110,12 +110,42 @@ readPandocBiblios ropt csl biblios item = do
 
 
 --------------------------------------------------------------------------------
+
+-- | Process a bibliography file with the given style.
+--
+-- This function supports pandoc's
+-- <https://pandoc.org/chunkedhtml-demo/9.6-including-uncited-items-in-the-bibliography.html nocite>
+-- functionality when there is a @nocite@ metadata field present.
+--
+-- ==== __Example__
+--
+-- In your main function, first compile the respective files:
+--
+-- > main = hakyll $ do
+-- >   …
+-- >   match "style.csl" $ compile cslCompiler
+-- >   match "bib.bib"   $ compile biblioCompiler
+--
+-- Then, create a function like the following:
+--
+-- > processBib :: Item Pandoc -> Compiler (Item Pandoc)
+-- > processBib pandoc = do
+-- >   csl <- load @CSL    "bib/style.csl"
+-- >   bib <- load @Biblio "bib/bibliography.bib"
+-- >   processPandocBiblio csl bib pandoc
+--
+-- Now, feed this function to your pandoc compiler:
+--
+-- > myCompiler :: Compiler (Item String)
+-- > myCompiler = pandocItemCompilerWithTransformM myReader myWriter processBib
 processPandocBiblio :: Item CSL
                     -> Item Biblio
                     -> (Item Pandoc)
                     -> Compiler (Item Pandoc)
 processPandocBiblio csl biblio = processPandocBiblios csl [biblio]
 
+-- | Like 'processPandocBiblio', which see, but support multiple bibliography
+-- files.
 processPandocBiblios :: Item CSL
                      -> [Item Biblio]
                      -> (Item Pandoc)


### PR DESCRIPTION
Adds support for pandocs [nocite](https://pandoc.org/chunkedhtml-demo/9.6-including-uncited-items-in-the-bibliography.html) functionality by having an appropriate field in the metadata of the site:

    nocite: |
      @citation1
      @citation2
      …

This adds `pandoc-types` as an explicit dependency, but it was already transient before that, so it's not really new. I also wrote some documentation (in a separate commit, but feel free to squash) so more people can understand how to actually use these functions.