### PR TITLE
Do not return broken symlinks from getRecursiveContents (#1061, #1062)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Releases
   throw an exception.
 - Ignore files in `dist-newstyle` and `.stack-work` directories, which
   are Haskell build directories.
+- Do not return broken symbolic links from
+  `Hakyll.Core.Util.File.getRecursiveContents`.  This used to cause
+  subsequent code to throw exceptions (e.g., when it attempts to
+  `getModificationTime`).
 
 # Releases
 

--- a/lib/Hakyll/Core/Util/File.hs
+++ b/lib/Hakyll/Core/Util/File.hs
@@ -62,7 +62,7 @@ getRecursiveContents ignore top = go ""
             then return []
             else do
                 names <- getProperDirectoryContents absDir
-                concat <$> forM names $ \name -> do
+                fmap concat . forM names $ \name -> do
                     let relPath = relDir </> name
                         absPath = top </> relPath
                     isDirectory <- doesDirectoryExist absPath


### PR DESCRIPTION
This is mostly for fixing #1061 but it also addresses some concerns discussed in #1062