### PR TITLE
Add support for typst

### DIFF
--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -67,6 +67,7 @@ readPandocWith ropt item =
         MediaWiki          -> readMediaWiki ro
         OrgMode            -> readOrg ro
         Rst                -> readRST ro
+        Typst              -> readTypst ro
         Textile            -> readTextile ro
         _                  -> error $
             "Hakyll.Web.readPandocWith: I don't know how to read a file of " ++

--- a/lib/Hakyll/Web/Pandoc/FileType.hs
+++ b/lib/Hakyll/Web/Pandoc/FileType.hs
@@ -33,6 +33,7 @@ data FileType
     | PlainText
     | Rst
     | Textile
+    | Typst
     deriving (Eq, Ord, Show, Read)
 
 
@@ -66,6 +67,7 @@ fileType = uncurry fileType' . splitExtension
     fileType' _ ".text"      = PlainText
     fileType' _ ".textile"   = Textile
     fileType' _ ".txt"       = PlainText
+    fileType' _ ".typ"       = Typst
     fileType' _ ".wiki"      = MediaWiki
     fileType' _ _            = Binary  -- Treat unknown files as binary
 


### PR DESCRIPTION
Pandoc supports Typst as an input filetype. This tiny pull request adds the ability for Hakyll to read typst files.