### PR TITLE
Simplify replaceAll and splitAll in Hakyll.Core.Util.String

### DIFF
--- a/lib/Hakyll/Core/Util/String.hs
+++ b/lib/Hakyll/Core/Util/String.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, ScopedTypeVariables #-}
 --------------------------------------------------------------------------------
 -- | Miscellaneous string manipulation functions.
 module Hakyll.Core.Util.String
@@ -13,7 +13,6 @@ module Hakyll.Core.Util.String
 --------------------------------------------------------------------------------
 import Data.Char (isSpace)
 import Data.List (isPrefixOf)
-import Data.Maybe (listToMaybe)
 import Text.Regex.TDFA ((=~~))
 
 
@@ -33,12 +32,9 @@ replaceAll :: String              -- ^ Pattern
            -> String              -- ^ Result
 replaceAll pattern f source = replaceAll' source
   where
-    replaceAll' src = case listToMaybe (src =~~ pattern) of
-        Nothing     -> src
-        Just (o, l) ->
-            let (before, tmp) = splitAt o src
-                (capture, after) = splitAt l tmp
-            in before ++ f capture ++ replaceAll' after
+    replaceAll' src = case src =~~ pattern of
+        Nothing                       -> src
+        Just (before, capture, after) -> before ++ f capture ++ replaceAll' after
 
 
 --------------------------------------------------------------------------------
@@ -49,11 +45,9 @@ splitAll :: String    -- ^ Pattern
          -> [String]  -- ^ Result
 splitAll pattern = filter (not . null) . splitAll'
   where
-    splitAll' src = case listToMaybe (src =~~ pattern) of
-        Nothing     -> [src]
-        Just (o, l) ->
-            let (before, tmp) = splitAt o src
-            in before : splitAll' (drop l tmp)
+    splitAll' src = case src =~~ pattern of
+        Nothing                         -> [src]
+        Just (before, _::String, after) -> before : splitAll' after
 
 
 

--- a/lib/Hakyll/Core/Util/String.hs
+++ b/lib/Hakyll/Core/Util/String.hs
@@ -32,6 +32,7 @@ replaceAll :: String              -- ^ Pattern
            -> String              -- ^ Result
 replaceAll pattern f source = replaceAll' source
   where
+    replaceAll' ""  = ""
     replaceAll' src = case src =~~ pattern of
         Nothing                       -> src
         Just (before, capture, after) -> before ++ f capture ++ replaceAll' after
@@ -45,6 +46,7 @@ splitAll :: String    -- ^ Pattern
          -> [String]  -- ^ Result
 splitAll pattern = filter (not . null) . splitAll'
   where
+    splitAll' ""  = []
     splitAll' src = case src =~~ pattern of
         Nothing                         -> [src]
         Just (before, _::String, after) -> before : splitAll' after

--- a/tests/Hakyll/Core/Util/String/Tests.hs
+++ b/tests/Hakyll/Core/Util/String/Tests.hs
@@ -22,11 +22,23 @@ tests = testGroup "Hakyll.Core.Util.String.Tests" $ concat
         ]
 
     , fromAssertions "replaceAll"
-        [ "32 & 131" @=? replaceAll "0x[0-9]+" (show . readInt) "0x20 & 0x83"
+        [ "foo-end"       @=? replaceAll "begin"       (const "foo")    "begin-end"
+        , "begin-foo"     @=? replaceAll "end"         (const "foo")    "begin-end"
+        , "no match"      @=? replaceAll "abc"         (const "foo")    "no match"
+        , "foo"           @=? replaceAll ".*"          (const "foo")    "full match"
+        , "empty pattern" @=? replaceAll ""            (const "foo")    "empty pattern"
+        , ""              @=? replaceAll "empty input" (const "foo")    ""
+        , "32 & 131"      @=? replaceAll "0x[0-9]+"    (show . readInt) "0x20 & 0x83"
         ]
 
     , fromAssertions "splitAll"
-        [ ["λ", "∀x.x", "hi"] @=? splitAll ", *" "λ, ∀x.x,  hi"
+        [ ["a", "b", "c"]     @=? splitAll ","           "a,,b,,,c,,"
+        , ["abc", "def"]      @=? splitAll "[0-9]+"      "abc123def456"
+        , ["no match"]        @=? splitAll ","           "no match"
+        , []                  @=? splitAll ".*"          "full match"
+        , ["empty pattern"]   @=? splitAll ""            "empty pattern"
+        , []                  @=? splitAll "empty input" ""
+        , ["λ", "∀x.x", "hi"] @=? splitAll ", *"         "λ, ∀x.x,  hi"
         ]
 
     , fromAssertions "needlePrefix"


### PR DESCRIPTION
`(=~~)` is polymorphic in its return type. Get first match + before/after directly, instead of splitting manually on match indices. Moreover, since `=~~` uses `'fail'` on lack of match, and `Maybe` is an instance of `MonadFail`, `listToMaybe` isn't necessary.