### PR TITLE
Bump pandoc dependency bounds to include 3.7

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -252,7 +252,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.7,
+      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.8,
       pandoc-types >= 1.22 && < 1.24
     Cpp-options:
       -DUSE_PANDOC
@@ -318,7 +318,7 @@ Test-suite hakyll-tests
     Cpp-options:
       -DUSE_PANDOC
     Build-Depends:
-      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.7,
+      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.8,
       pandoc-types >= 1.22 && < 1.24
 
 
@@ -353,5 +353,5 @@ Executable hakyll-website
     base      >= 4.12  && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.6,
-    pandoc    >= 2.11  && < 2.20 || >= 3.0 && < 3.7,
+    pandoc    >= 2.11  && < 2.20 || >= 3.0 && < 3.8,
     pandoc-types >= 1.22 && < 1.24


### PR DESCRIPTION
Fixes #1071 

I tested locally using `cabal test --constraint="pandoc==3.7"`.