### PR TITLE
Update bound on optparse-applicative to include 0.19

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -201,7 +201,7 @@ Library
     lrucache             >= 1.1.1    && < 1.3,
     mtl                  >= 1        && < 2.4,
     network-uri          >= 2.6      && < 2.7,
-    optparse-applicative >= 0.12     && < 0.19,
+    optparse-applicative >= 0.12     && < 0.20,
     parsec               >= 3.0      && < 3.2,
     process              >= 1.6      && < 1.7,
     random               >= 1.0      && < 1.4,


### PR DESCRIPTION
I was able to test locally using:

```
cabal build --constraint="optparse-applicative==0.19.0.0"
```

Since there are no code changes, I will revise the latest Hakyll version once this PR is merged