### PR TITLE
Allow QuickCheck 2.16

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -285,7 +285,7 @@ Test-suite hakyll-tests
 
   Build-Depends:
     hakyll,
-    QuickCheck                 >= 2.8  && < 2.16,
+    QuickCheck                 >= 2.8  && < 2.17,
     tasty                      >= 0.11 && < 1.6,
     tasty-golden               >= 2.3  && < 2.4,
     tasty-hunit                >= 0.9  && < 0.11,


### PR DESCRIPTION
This was tested manually using:

```
cabal test --constraint="QuickCheck==2.16.0.0"  --allow-newer=QuickCheck
```

Note that `allow-newer` is required since `tasty-quickckeck` doesn't yet support QuickCheck 2.16

See https://github.com/commercialhaskell/stackage/issues/7778