### PR TITLE
Re-link pandoc in the site to `https://pandoc.org/` 

### DIFF
--- a/web/index.markdown
+++ b/web/index.markdown
@@ -12,7 +12,7 @@ mostly aimed at small-to-medium sites and personal blogs. It is written in a
 very configurable way and uses an [xmonad](http://xmonad.org)-like DSL for
 configuration.
 
-Integration with [pandoc](http://johnmacfarlane.net/pandoc/) gives us markdown
+Integration with [pandoc](https://pandoc.org/) gives us markdown
 and TeX support, including syntax highlighting and other goodies.
 
 # The Hakyll System


### PR DESCRIPTION
The previous link is link to the broken site of John McFarlane like the picture below.
<img width="1250" height="234" alt="image" src="https://github.com/user-attachments/assets/7ea5221c-399f-409d-b298-f730cc1b123c" />
So, I link to official site instead.