### PR TITLE
Support for pandoc 3.8

### DIFF
--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -253,7 +253,7 @@ Library
     Other-Modules:
       Hakyll.Web.Pandoc.Binary
     Build-Depends:
-      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.8,
+      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.9,
       pandoc-types >= 1.22 && < 1.24
     Cpp-options:
       -DUSE_PANDOC
@@ -320,7 +320,7 @@ Test-suite hakyll-tests
     Cpp-options:
       -DUSE_PANDOC
     Build-Depends:
-      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.8,
+      pandoc >= 2.11 && < 2.20 || >= 3.0 && < 3.9,
       pandoc-types >= 1.22 && < 1.24
 
 
@@ -355,5 +355,5 @@ Executable hakyll-website
     base      >= 4.12  && < 5,
     directory >= 1.0   && < 1.4,
     filepath  >= 1.0   && < 1.6,
-    pandoc    >= 2.11  && < 2.20 || >= 3.0 && < 3.8,
+    pandoc    >= 2.11  && < 2.20 || >= 3.0 && < 3.9,
     pandoc-types >= 1.22 && < 1.24

--- a/lib/Hakyll/Web/Pandoc.hs
+++ b/lib/Hakyll/Web/Pandoc.hs
@@ -230,7 +230,14 @@ defaultHakyllWriterOptions = def
       writerExtensions = enableExtension Ext_smart pandocExtensions
     , -- We want to have hightlighting by default, to be compatible with earlier
       -- Hakyll releases
+#if MIN_VERSION_pandoc(3,8,0)
+      -- Starting with pandoc 3.8, the highlighting
+      -- system was overhauled to have more than just Skylighting
+      -- styles
+      writerHighlightMethod = Skylighting pygments
+#else
       writerHighlightStyle = Just pygments
+#endif
     , -- Do not word-wrap produced HTML, and do not undo any word-wrapping
       -- that's already present in the markup. This is how Pandoc operated
       -- prior to 2.17, but the behaviour was changed for consistency with


### PR DESCRIPTION
This PR adds support for pandoc-3.8 in hakyll.

Note that pandoc 3.8 changed the way syntax highlighting is specified in `WriterOptions`. Therefore, to support pandoc 3 - 3.8 inclusively, we need to use CPP :(

I tested locally that Hakyll now compiles with pandoc 3.6 and pandoc 3.8 using:

```
cabal test --constraint="pandoc<=3.6"
cabal test --constraint="pandoc>=3.8"
```

which both passed all tests.

Fixes #1079 