### PR TITLE
Add support for declaring metadata-only dependencies

### DIFF
--- a/lib/Hakyll/Core/Compiler.hs
+++ b/lib/Hakyll/Core/Compiler.hs
@@ -82,7 +82,7 @@ getRoute identifier = do
     -- Note that this makes us dependend on that identifier: when the metadata
     -- of that item changes, the route may change, hence we have to recompile
     (mfp, um) <- compilerUnsafeIO $ runRoutes routes provider identifier
-    when um $ compilerTellDependencies [IdentifierDependency identifier]
+    when um $ compilerTellDependencies [metadataDependency $ IdentifierDependency identifier]
     return mfp
 
 

--- a/lib/Hakyll/Core/Compiler/Internal.hs
+++ b/lib/Hakyll/Core/Compiler/Internal.hs
@@ -346,7 +346,7 @@ compilerTellCacheHits ch = compilerTell mempty {compilerCacheHits = ch}
 compilerGetMetadata :: Identifier -> Compiler Metadata
 compilerGetMetadata identifier = do
     provider <- compilerProvider <$> compilerAsk
-    compilerTellDependencies [IdentifierDependency identifier]
+    compilerTellDependencies [metadataDependency $ IdentifierDependency identifier]
     compilerUnsafeIO $ resourceMetadata provider identifier
 
 
@@ -355,5 +355,5 @@ compilerGetMatches :: Pattern -> Compiler [Identifier]
 compilerGetMatches pattern = do
     universe <- compilerUniverse <$> compilerAsk
     let matching = S.filter (matches pattern) universe
-    compilerTellDependencies [PatternDependency pattern matching]
+    compilerTellDependencies [contentDependency $ PatternDependency pattern matching]
     pure $ S.toList matching

--- a/lib/Hakyll/Core/Compiler/Require.hs
+++ b/lib/Hakyll/Core/Compiler/Require.hs
@@ -105,7 +105,7 @@ loadSnapshotCollection ids = do
             when (id' `S.notMember` universe) (fail $ notFound id' snap)
     traverse_ checkMember ids
 
-    compilerTellDependencies $ IdentifierDependency . fst <$> toList ids
+    compilerTellDependencies $ contentDependency . IdentifierDependency . fst <$> toList ids
     let go (id', snap) = do
             result <- compilerUnsafeIO $ Store.get store (key id' snap)
             case result of

--- a/lib/Hakyll/Core/Dependencies.hs
+++ b/lib/Hakyll/Core/Dependencies.hs
@@ -1,9 +1,14 @@
 --------------------------------------------------------------------------------
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE TupleSections #-}
 module Hakyll.Core.Dependencies
     ( Dependency (..)
+    , DependencySelector (..)
+    , DependencyKind (..)
     , DependencyFacts
     , outOfDate
+    , contentDependency
+    , metadataDependency
     ) where
 
 
@@ -15,6 +20,7 @@ import qualified Control.Monad.State            as State
 import           Control.Monad.Writer           (tell)
 import           Data.Binary                    (Binary (..), getWord8,
                                                  putWord8)
+import           Data.Functor                   ((<&>))
 import           Data.List                      (find)
 import           Data.Map                       (Map)
 import qualified Data.Map                       as M
@@ -30,23 +36,54 @@ import           Hakyll.Core.Identifier.Pattern
 
 
 --------------------------------------------------------------------------------
-data Dependency
+data DependencySelector
     = PatternDependency Pattern (Set Identifier)
     | IdentifierDependency Identifier
+    deriving (Show, Typeable)
+
+--------------------------------------------------------------------------------
+instance Binary DependencySelector where
+    put (PatternDependency p is) = putWord8 0 >> put p >> put is
+    put (IdentifierDependency i) = putWord8 1 >> put i
+    get = getWord8 >>= \t -> case t of
+        0 -> PatternDependency <$> get <*> get
+        1 -> IdentifierDependency <$> get
+        _ -> fail "Data.Binary.get: Invalid DependencySelector"
+
+
+--------------------------------------------------------------------------------
+-- | A data type representing a dependency on another 'Identifier'. We can
+-- depend either on the 'Hakyll.Core.Metadata.Metadata' or the entire content of
+-- the underlying file. This is signified by the supplied 'DependencyKind'.
+data Dependency
+    = Dependency DependencyKind DependencySelector
     | AlwaysOutOfDate
     deriving (Show, Typeable)
 
 
 --------------------------------------------------------------------------------
+-- | Utility function to create a new content dependency.
+contentDependency :: DependencySelector -> Dependency
+contentDependency = Dependency KindContent
+
+-- | Utility function to a create a new metadata dependency.
+metadataDependency :: DependencySelector -> Dependency
+metadataDependency = Dependency KindMetadata
+
+
+--------------------------------------------------------------------------------
 instance Binary Dependency where
-    put (PatternDependency p is) = putWord8 0 >> put p >> put is
-    put (IdentifierDependency i) = putWord8 1 >> put i
     put AlwaysOutOfDate = putWord8 2
+    put (Dependency k s) = putWord8 3 >> put k >> put s
+
     get = getWord8 >>= \t -> case t of
-        0 -> PatternDependency <$> get <*> get
-        1 -> IdentifierDependency <$> get
+        -- XXX: Backwards compatability with Hakyll <=4.16.7.1.
+        0 -> (\p i -> contentDependency $ PatternDependency p i) <$> get <*> get
+        1 -> contentDependency . IdentifierDependency <$> get
+
         2 -> pure AlwaysOutOfDate
-        _ -> error "Data.Binary.get: Invalid Dependency"
+        3 -> Dependency <$> get <*> get
+        _ -> fail "Data.Binary.get: Invalid Dependency"
 
 
 --------------------------------------------------------------------------------
@@ -89,14 +126,24 @@ markOod id' = State.modify $ \s ->
 
 
 --------------------------------------------------------------------------------
+data DependencyKind = KindContent | KindMetadata
+  deriving (Show)
+
+instance Binary DependencyKind where
+  put KindContent = putWord8 0
+  put KindMetadata = putWord8 1
+
+  get = getWord8 >>= \t -> case t of
+      0 -> pure KindContent
+      1 -> pure KindMetadata
+      _ -> fail "Data.Binary.get: Invalid DependencyKind"
+
+--------------------------------------------------------------------------------
 -- | Collection of dependencies that should be checked to determine
 -- if an identifier needs rebuilding.
 data Dependencies
   = DependsOn [(DependencyKind, Identifier)]
   | MustRebuild
-  deriving (Show)
-
-data DependencyKind = KindContent | KindMetadata
   deriving (Show)
 
 instance Semigroup Dependencies where
@@ -113,9 +160,12 @@ dependenciesFor id' = do
     facts <- dependencyFacts <$> State.get
     return $ foldMap dependenciesFor' $ fromMaybe [] $ M.lookup id' facts
   where
-    dependenciesFor' (IdentifierDependency i) = DependsOn [(KindContent, i)]
-    dependenciesFor' (PatternDependency _ is) = DependsOn $ map (\i -> (KindContent, i)) (S.toList is)
-    dependenciesFor' AlwaysOutOfDate          = MustRebuild
+    dependenciesForSelector (IdentifierDependency i) = [i]
+    dependenciesForSelector (PatternDependency _ is) = S.toList is
+
+    dependenciesFor' AlwaysOutOfDate            = MustRebuild
+    dependenciesFor' (Dependency kind selector) = DependsOn $
+        map (kind,) $ dependenciesForSelector selector
 
 
 --------------------------------------------------------------------------------
@@ -137,17 +187,19 @@ checkChangedPatterns = do
         State.modify $ \s -> s
             {dependencyFacts = M.insert id' deps' $ dependencyFacts s}
   where
-    go _   ds (IdentifierDependency i) = return $ IdentifierDependency i : ds
-    go _   ds AlwaysOutOfDate          = return $ AlwaysOutOfDate : ds
-    go id' ds (PatternDependency p ls) = do
+    go' _   (IdentifierDependency i) = return $ IdentifierDependency i
+    go' id' (PatternDependency p ls) = do
         universe <- ask
         let ls' = S.fromList $ filterMatches p universe
         if ls == ls'
-            then return $ PatternDependency p ls : ds
+            then return $ PatternDependency p ls
             else do
                 tell [show id' ++ " is out-of-date because a pattern changed"]
                 markOod id'
-                return $ PatternDependency p ls' : ds
+                return $ PatternDependency p ls'
+
+    go _   ds AlwaysOutOfDate          = return $ AlwaysOutOfDate : ds
+    go id' ds (Dependency kind select) = (Dependency kind <$> go' id' select) <&> (: ds)
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Core/Metadata.hs
+++ b/lib/Hakyll/Core/Metadata.hs
@@ -84,10 +84,10 @@ getMetadataField' identifier key = do
 
 
 --------------------------------------------------------------------------------
-makePatternDependency :: MonadMetadata m => Pattern -> m Dependency
-makePatternDependency pattern = do
+makePatternDependency :: MonadMetadata m => DependencyKind -> Pattern -> m Dependency
+makePatternDependency kind pattern = do
     matches' <- getMatches pattern
-    return $ PatternDependency pattern (S.fromList matches')
+    return $ Dependency kind (PatternDependency pattern (S.fromList matches'))
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Core/Provider/MetadataCache.hs
+++ b/lib/Hakyll/Core/Provider/MetadataCache.hs
@@ -37,10 +37,19 @@ resourceBody p r = do
 
 
 --------------------------------------------------------------------------------
-resourceInvalidateMetadataCache :: Provider -> Identifier -> IO ()
+resourceInvalidateMetadataCache :: Provider -> Identifier -> IO (Metadata)
 resourceInvalidateMetadataCache p r = do
+    result <- Store.get (providerStore p)
+        [name, toFilePath r, "metadata"]
+    let md = case result of
+          Store.Found (BinaryMetadata m) -> m
+          Store.NotFound -> mempty
+          Store.WrongType _ _ -> error "unexpected WrongType"
+
     Store.delete (providerStore p) [name, toFilePath r, "metadata"]
     Store.delete (providerStore p) [name, toFilePath r, "body"]
+
+    pure md
 
 
 --------------------------------------------------------------------------------

--- a/lib/Hakyll/Web/Paginate.hs
+++ b/lib/Hakyll/Web/Paginate.hs
@@ -19,6 +19,7 @@ import qualified Data.Set                       as S
 
 --------------------------------------------------------------------------------
 import           Hakyll.Core.Compiler
+import           Hakyll.Core.Dependencies
 import           Hakyll.Core.Identifier
 import           Hakyll.Core.Identifier.Pattern
 import           Hakyll.Core.Item
@@ -68,7 +69,7 @@ buildPaginateWith grouper pattern makeId = do
     return Paginate
         { paginateMap        = M.fromList (zip [1 ..] idGroups)
         , paginateMakeId     = makeId
-        , paginateDependency = PatternDependency pattern idsSet
+        , paginateDependency = contentDependency $ PatternDependency pattern idsSet
         }
 
 

--- a/lib/Hakyll/Web/Tags.hs
+++ b/lib/Hakyll/Web/Tags.hs
@@ -136,7 +136,8 @@ buildTagsWith f pattern makeId = do
     ids    <- getMatches pattern
     tagMap <- foldM addTags M.empty ids
     let set' = S.fromList ids
-    return $ Tags (M.toList tagMap) makeId (PatternDependency pattern set')
+    return $ Tags (M.toList tagMap) makeId
+        (metadataDependency $ PatternDependency pattern set')
   where
     -- Create a tag map for one page
     addTags tagMap id' = do

--- a/tests/Hakyll/Core/Dependencies/Tests.hs
+++ b/tests/Hakyll/Core/Dependencies/Tests.hs
@@ -51,7 +51,7 @@ oldFacts = M.fromList
 case01 :: Assertion
 case01 = S.fromList ["posts/02.md", "index.md"] @=? ood
   where
-    (ood, _, _) = outOfDate oldUniverse (S.singleton "posts/02.md") oldFacts
+    (ood, _, _) = outOfDate oldUniverse (S.singleton "posts/02.md") S.empty oldFacts
 
 
 --------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ case01 = S.fromList ["posts/02.md", "index.md"] @=? ood
 case02 :: Assertion
 case02 = S.singleton "about.md" @=? ood
   where
-    (ood, _, _) = outOfDate ("about.md" : oldUniverse) S.empty oldFacts
+    (ood, _, _) = outOfDate ("about.md" : oldUniverse) S.empty S.empty oldFacts
 
 
 --------------------------------------------------------------------------------
@@ -68,4 +68,4 @@ case03 :: Assertion
 case03 = S.singleton "index.md" @=? ood
   where
     (ood, _, _) =
-        outOfDate ("posts/01.md" `delete` oldUniverse) S.empty oldFacts
+        outOfDate ("posts/01.md" `delete` oldUniverse) S.empty S.empty oldFacts

--- a/tests/TestSuite/Util.hs
+++ b/tests/TestSuite/Util.hs
@@ -48,8 +48,10 @@ newTestStore = Store.new True $ storeDirectory testConfiguration
 
 --------------------------------------------------------------------------------
 newTestProvider :: Store -> IO Provider
-newTestProvider store = newProvider store (const $ return False) $
-    providerDirectory testConfiguration
+newTestProvider store = do
+  let dir = providerDirectory testConfiguration
+  (p, _) <- newProvider store (const $ return False) dir
+  pure p
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Presently, it is not possible to only depend on the metadata of an item. This is problematic because it can cause a lot of unnecessary rebuilds when a compiler only needs to run on metadata changes. For example, consider a navigation sidebar that includes all tags of available posts. If this sidebar is included on every page, then we would always rebuild everything when changing the content of any post (even though the metadata tags themselves didn't change!).

To overcome this limitation, we need to distinguish between content and metadata dependencies. This is basically what #383 is about, where @jaspervdj also expressed interest in this feature. However, since nobody has worked on this [since 2015](https://github.com/jaspervdj/hakyll/issues/383#issuecomment-150836917), I decided to give it a shot.

The implementation proposed here is split into two commits, which can be reused independently. The first makes `outOfDate` capable of classifying Identifiers for which only the metadata changed. Building upon that, the second commit refactors `Hakyll.Core.Dependencies` (API-breaking change!) to introduce a `DependencyKind` which allows us to distinguish `KindContent` and `KindMetadata`. The commit also then makes use of the feature where applicable (`getRoute`, `compilerGetMetadata`, `buildTagsWith`). <!--There is potential to make more use of the feature, for example, providing a `loadMetadata` in `Hakyll.Core.Compiler.Require` but that presupposes agreeing on the new `Hakyll.Core.Dependencies` API and can probably be done separately.-->

Feedback and additional testing would be much appreciated! 🤗

---

Fixes #383