### PR TITLE
web: add my website as an additional example

### DIFF
--- a/web/examples.markdown
+++ b/web/examples.markdown
@@ -147,3 +147,5 @@ this list. This list has no particular ordering.
   [source](https://github.com/falgon/roki-web)
 - <https://julesh.com/>,
   [source](https://github.com/jules-hedges/jules-hedges.github.io)
+- <https://notes.8pit.net/>
+  [source](https://git.8pit.net/site/)


### PR DESCRIPTION
I think this might be interesting for others as it is not a blog but rather a personal wiki / public notebook / digital garden and hence requires a somewhat uncommon Hakyll setup.

See: https://notes.8pit.net