### PR TITLE
Use `description` field in Atom and JSON feeds

### DIFF
--- a/data/templates/atom.xml
+++ b/data/templates/atom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     <title>$title$</title>
+    <subtitle><![CDATA[$description$]]></subtitle>
     <link href="$root$$url$" rel="self" />
     <link href="$root$" />
     <id>$root$$url$</id>

--- a/data/templates/feed.json
+++ b/data/templates/feed.json
@@ -1,6 +1,7 @@
 {
     "version": "https://www.jsonfeed.org/version/1.1",
     "title": "$title$",
+    "description": "$description$",
     "home_page_url": "$root$",
     "feed_url": "$root$$url$",
     $if(authorName)$


### PR DESCRIPTION
Currently, only the RSS feed template utilizes the `$description$` field. This commit adds support for this field to the Atom and JSON feeds for consistency.

The description is used as the `<subtitle>` in Atom feeds and the `description` field in JSON feeds.