### PR TITLE
Allow QuickCheck 2.17 and 2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ title: Releases
 
 # Releases
 
-## 4.15.8.0
+## Unreleased
+
+- Added support for QuickCheck 2.17 and 2.18 (#1099).
+
+## 4.16.8.0
 
 - Added support for djot for pandoc 3.1.12+ (#1096)
 - Added support for pandoc 3.9 (#1095)

--- a/hakyll.cabal
+++ b/hakyll.cabal
@@ -291,7 +291,7 @@ Test-suite hakyll-tests
 
   Build-Depends:
     hakyll,
-    QuickCheck                 >= 2.8  && < 2.17,
+    QuickCheck                 >= 2.8  && < 2.19,
     tasty                      >= 0.11 && < 1.6,
     tasty-golden               >= 2.3  && < 2.4,
     tasty-hunit                >= 0.9  && < 0.11,


### PR DESCRIPTION
Tested with:

```
cabal test hakyll --constraint="QuickCheck>2.17"
```