### PR TITLE
Re-export Hakyll.Core.Dependencies from Hakyll module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ title: Releases
 ## 4.17.1.0
 
 - Added support for `aeson` 2.3
+- Re-export `Hakyll.Core.Dependencies` from `Hakyll` (#1104)
 
 ## 4.17.0.0
 

--- a/lib/Hakyll.hs
+++ b/lib/Hakyll.hs
@@ -4,6 +4,7 @@
 module Hakyll
     ( module Hakyll.Core.Compiler
     , module Hakyll.Core.Configuration
+    , module Hakyll.Core.Dependencies
     , module Hakyll.Core.File
     , module Hakyll.Core.Identifier
     , module Hakyll.Core.Identifier.Pattern
@@ -40,6 +41,7 @@ module Hakyll
 --------------------------------------------------------------------------------
 import           Hakyll.Core.Compiler
 import           Hakyll.Core.Configuration
+import           Hakyll.Core.Dependencies
 import           Hakyll.Core.File
 import           Hakyll.Core.Identifier
 import           Hakyll.Core.Identifier.Pattern


### PR DESCRIPTION
Otherwise, since #1084, it is not possible to declare dependencies without explicitly importing the `Hakyll.Core.Dependencies` module. Since this was previously possible, it may be worthwhile to also re-export `Hakyll.Core.Dependencies` from the Hakyll module.

See https://github.com/jaspervdj/hakyll/pull/1084#issuecomment-4686676091